### PR TITLE
Support long press for buttons

### DIFF
--- a/buttons.h
+++ b/buttons.h
@@ -15,13 +15,15 @@ struct ButtonData {
     const char *label;
     lv_color_t color;
     button_callback callback;
-    bool toggleable; // <--- this was added to enable toggling
+    bool toggleable; // <--- enables toggling
+    bool long_press; // if true the button requires a long press
 };
 
 class ButtonSquare {
 public:
     ButtonSquare(lv_obj_t *parent_grid, const ButtonData &data, uint8_t grid_col, uint8_t grid_row);
-    void handlePress();
+    void onPress();
+    void onRelease();
     void updateVisual();
 
     const char *getLabel() const { return label; }
@@ -35,8 +37,10 @@ private:
     lv_obj_t *label_obj;
     lv_style_t style;
 
-    bool toggleable; // <--- new field
-    bool toggled = false; // <--- new field
+    bool toggleable;
+    bool long_press;
+    bool toggled = false;
+    unsigned long press_start = 0;
 };
 
 #endif

--- a/config.h
+++ b/config.h
@@ -8,25 +8,25 @@
 void null_btn(lv_event_t *e); 
 
 const ButtonData button_panel1[BUTTON_COUNT] = {
-    { "TURBO BOOST", RED, null_btn, true },
-    { "MAP SYSTEM", YELLOW, null_btn, false },
-    { "SKI MODE", WHITE, null_btn, false },
-    { "VOLTAGE OUTPUT", YELLOW, null_btn, false },
-    { "VITAL SCAN", GREEN, null_btn, false },
-    { "EVADE", GREEN, null_btn, false },
-    { "RANGE BRITE", GREEN, null_btn, false },
-    { "RADAR IMAGE", GREEN, null_btn, false },
+    { "TURBO BOOST", RED, null_btn, true, true },
+    { "MAP SYSTEM", YELLOW, null_btn, false, false },
+    { "SKI MODE", WHITE, null_btn, false, false },
+    { "VOLTAGE OUTPUT", YELLOW, null_btn, false, false },
+    { "VITAL SCAN", GREEN, null_btn, false, false },
+    { "EVADE", GREEN, null_btn, false, false },
+    { "RANGE BRITE", GREEN, null_btn, false, false },
+    { "RADAR IMAGE", GREEN, null_btn, false, false },
 };
 
 const ButtonData button_panel2[BUTTON_COUNT] = {
-    { "BAD DOLPHINS", RED, null_btn, true },
-    { "NERVE GAS", YELLOW, null_btn, false },
-    { "SHARKS", WHITE, null_btn, false },
-    { "CUTE OTTERS", YELLOW, null_btn, false },
-    { "EMERGENCY METH", GREEN, null_btn, false },
-    { "SCARLETT JOHANSSON", RED, null_btn, true },
-    { "BROWNIES", GREEN, null_btn, false },
-    { "POT BROWNIES", GREEN, null_btn, false },
+    { "BAD DOLPHINS", RED, null_btn, true, true },
+    { "NERVE GAS", YELLOW, null_btn, false, false },
+    { "SHARKS", WHITE, null_btn, false, false },
+    { "CUTE OTTERS", YELLOW, null_btn, false, false },
+    { "EMERGENCY METH", GREEN, null_btn, false, false },
+    { "SCARLETT JOHANSSON", RED, null_btn, true, true },
+    { "BROWNIES", GREEN, null_btn, false, false },
+    { "POT BROWNIES", GREEN, null_btn, false, false },
 };
 
 #endif


### PR DESCRIPTION
## Summary
- add `long_press` flag to `ButtonData` and `ButtonSquare`
- handle LVGL press/release events and toggle only after 1s hold when `long_press` is set
- update button configuration to specify which buttons need a long press

## Testing
- `g++ -c buttons.cpp -I. -std=c++17` *(fails: lvgl.h not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843bd7d086c8329a799778e74dd28df