### PR TITLE
Fix redundant members in ButtonSquare

### DIFF
--- a/buttons.h
+++ b/buttons.h
@@ -22,8 +22,7 @@ struct ButtonData {
 class ButtonSquare {
 public:
     ButtonSquare(lv_obj_t *parent_grid, const ButtonData &data, uint8_t grid_col, uint8_t grid_row);
-    void onPress();
-    void onRelease();
+    void handlePress();
     void updateVisual();
     void eventHandler(lv_event_t* e);
 
@@ -45,14 +44,8 @@ private:
     uint32_t press_start = 0;
     bool long_press_handled = false;
 
-    uint16_t long_press_time = 0;
-    uint32_t press_start = 0;
-    bool long_press_handled = false;
-
     bool toggleable;
-    bool long_press;
     bool toggled = false;
-    unsigned long press_start = 0;
 };
 
 #endif


### PR DESCRIPTION
## Summary
- remove duplicate member declarations in `buttons.h`
- declare `handlePress` instead of unused `onPress`/`onRelease`

## Testing
- `g++ -c -std=c++17 buttons.cpp -I.` *(fails: lvgl.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_6843c49c57b483298ddd61141b6662c9