### PR TITLE
Add voice visualiser tile mockup

### DIFF
--- a/buttons.h
+++ b/buttons.h
@@ -49,6 +49,10 @@ private:
     lv_color_t color_off;
     lv_color_t color_on;
 
+    uint16_t long_press_time = 0;
+    uint32_t press_start = 0;
+    bool long_press_handled = false;
+
     bool toggleable;
     bool toggled = false;
 };

--- a/kitt.ino
+++ b/kitt.ino
@@ -7,6 +7,7 @@
 #include "buttons.h"
 #include "button_panel.h"
 #include "config.h"
+#include "voice_scene.h"
 
 GigaDisplay_GFX tft; // Init tft
 Arduino_GigaDisplayTouch TouchDetector;
@@ -17,6 +18,11 @@ void make_panel(ButtonData const* config, lv_obj_t* tileview, int row_id) {
 
     new ButtonPanel(tile, config);
 }
+
+ButtonData const voice_buttons[2] = {
+    { "LISTEN", null_btn, false, 0 },
+    { "CANCEL", null_btn, false, 0 },
+};
 
 void setup() {
   Serial.begin(115200); // Initialize Serial
@@ -32,7 +38,8 @@ void setup() {
   lv_obj_set_scrollbar_mode(tiles, LV_SCROLLBAR_MODE_OFF);
 
   make_panel(button_panel1, tiles, 0);
-  make_panel(button_panel2, tiles, 1);
+  create_voice_tile(tiles, 1, voice_buttons);
+  make_panel(button_panel2, tiles, 2);
 }
 
 void loop() {

--- a/voice_scene.cpp
+++ b/voice_scene.cpp
@@ -8,7 +8,8 @@ lv_obj_t* create_voice_tile(lv_obj_t* tileview, int row_id, ButtonData const* bu
     int spacing = 20;
     int button_size = (480 - spacing * 3) / 2; // bottom buttons width (screen width 480)
     int grid_width = button_size * 2 + spacing * 3;
-    int grid_height = 800; // full screen height
+    int viz_height = 320; // allow room for buttons
+    int grid_height = viz_height + button_size + spacing * 3;
 
     lv_obj_t* grid = lv_obj_create(tile);
     lv_obj_remove_style_all(grid);
@@ -17,7 +18,7 @@ lv_obj_t* create_voice_tile(lv_obj_t* tileview, int row_id, ButtonData const* bu
     lv_obj_center(grid);
 
     static lv_coord_t col_dsc[] = {button_size, button_size, LV_GRID_TEMPLATE_LAST};
-    static lv_coord_t row_dsc[] = {600, button_size, LV_GRID_TEMPLATE_LAST};
+    static lv_coord_t row_dsc[] = {viz_height, button_size, LV_GRID_TEMPLATE_LAST};
     lv_obj_set_grid_dsc_array(grid, col_dsc, row_dsc);
     lv_obj_set_style_pad_all(grid, spacing, 0);
     lv_obj_set_style_pad_row(grid, spacing, 0);
@@ -35,11 +36,11 @@ lv_obj_t* create_voice_tile(lv_obj_t* tileview, int row_id, ButtonData const* bu
     lv_obj_set_flex_align(viz, LV_FLEX_ALIGN_SPACE_EVENLY,
                           LV_FLEX_ALIGN_END, LV_FLEX_ALIGN_CENTER);
 
-    static int heights[5] = {150, 300, 450, 300, 150};
+    static int heights[5] = {100, 220, 300, 220, 100};
     for(int i = 0; i < 5; ++i) {
         lv_obj_t* bar = lv_obj_create(viz);
         lv_obj_remove_style_all(bar);
-        lv_obj_set_style_bg_color(bar, GREEN, 0);
+        lv_obj_set_style_bg_color(bar, RED_DARK, 0);
         lv_obj_set_style_radius(bar, 10, 0);
         lv_obj_set_size(bar, 30, heights[i]);
     }

--- a/voice_scene.cpp
+++ b/voice_scene.cpp
@@ -1,0 +1,54 @@
+#include "buttons.h"
+
+lv_obj_t* create_voice_tile(lv_obj_t* tileview, int row_id, ButtonData const* buttons) {
+    auto* tile = lv_tileview_add_tile(tileview, row_id, 0, LV_DIR_HOR);
+    lv_obj_set_style_bg_color(tile, BLACK, 0);
+
+    int spacing = 20;
+    int button_size = (480 - spacing * 3) / 2; // bottom buttons width (screen width 480)
+    int grid_width = button_size * 2 + spacing * 3;
+    int grid_height = 800; // full screen height
+
+    lv_obj_t* grid = lv_obj_create(tile);
+    lv_obj_remove_style_all(grid);
+    lv_obj_set_layout(grid, LV_LAYOUT_GRID);
+    lv_obj_set_size(grid, grid_width, grid_height);
+    lv_obj_center(grid);
+
+    static lv_coord_t col_dsc[] = {button_size, button_size, LV_GRID_TEMPLATE_LAST};
+    static lv_coord_t row_dsc[] = {600, button_size, LV_GRID_TEMPLATE_LAST};
+    lv_obj_set_grid_dsc_array(grid, col_dsc, row_dsc);
+    lv_obj_set_style_pad_all(grid, spacing, 0);
+    lv_obj_set_style_pad_row(grid, spacing, 0);
+    lv_obj_set_style_pad_column(grid, spacing, 0);
+
+    // Visualizer mockup using rounded rectangles
+    lv_obj_t* viz = lv_obj_create(grid);
+    lv_obj_remove_style_all(viz);
+    lv_obj_set_style_bg_color(viz, BLACK, 0);
+    lv_obj_set_grid_cell(viz, LV_GRID_ALIGN_STRETCH, 0, 2,
+                         LV_GRID_ALIGN_STRETCH, 0, 1);
+    lv_obj_set_style_pad_all(viz, 10, 0);
+    lv_obj_set_layout(viz, LV_LAYOUT_FLEX);
+    lv_obj_set_flex_flow(viz, LV_FLEX_FLOW_ROW);
+    lv_obj_set_flex_align(viz, LV_FLEX_ALIGN_SPACE_EVENLY,
+                          LV_FLEX_ALIGN_END, LV_FLEX_ALIGN_CENTER);
+
+    static int heights[5] = {150, 300, 450, 300, 150};
+    for(int i = 0; i < 5; ++i) {
+        lv_obj_t* bar = lv_obj_create(viz);
+        lv_obj_remove_style_all(bar);
+        lv_obj_set_style_bg_color(bar, GREEN, 0);
+        lv_obj_set_style_radius(bar, 10, 0);
+        lv_obj_set_size(bar, 30, heights[i]);
+    }
+
+    // Two buttons at bottom row
+    ButtonSquare* btn0 = new ButtonSquare(grid, buttons[0], 0, 1);
+    ButtonSquare* btn1 = new ButtonSquare(grid, buttons[1], 1, 1);
+
+    LV_UNUSED(btn0); // avoid unused warnings if compiled
+    LV_UNUSED(btn1);
+
+    return tile;
+}

--- a/voice_scene.cpp
+++ b/voice_scene.cpp
@@ -8,8 +8,10 @@ lv_obj_t* create_voice_tile(lv_obj_t* tileview, int row_id, ButtonData const* bu
     int spacing = 20;
     int button_size = (480 - spacing * 3) / 2; // bottom buttons width (screen width 480)
     int grid_width = button_size * 2 + spacing * 3;
-    int viz_height = 320; // allow room for buttons
-    int grid_height = viz_height + button_size + spacing * 3;
+
+    // Fill the screen height so the buttons sit at the very bottom
+    int grid_height = 800;
+    int viz_height = grid_height - button_size - spacing * 3;
 
     lv_obj_t* grid = lv_obj_create(tile);
     lv_obj_remove_style_all(grid);
@@ -24,26 +26,49 @@ lv_obj_t* create_voice_tile(lv_obj_t* tileview, int row_id, ButtonData const* bu
     lv_obj_set_style_pad_row(grid, spacing, 0);
     lv_obj_set_style_pad_column(grid, spacing, 0);
 
-    // Visualizer mockup using rounded rectangles
+    // Visualizer mockup using three columns of rounded rectangles
     lv_obj_t* viz = lv_obj_create(grid);
     lv_obj_remove_style_all(viz);
     lv_obj_set_style_bg_color(viz, BLACK, 0);
     lv_obj_set_grid_cell(viz, LV_GRID_ALIGN_STRETCH, 0, 2,
                          LV_GRID_ALIGN_STRETCH, 0, 1);
     lv_obj_set_style_pad_all(viz, 10, 0);
+    lv_obj_set_style_pad_column(viz, 15, 0);
     lv_obj_set_layout(viz, LV_LAYOUT_FLEX);
     lv_obj_set_flex_flow(viz, LV_FLEX_FLOW_ROW);
-    lv_obj_set_flex_align(viz, LV_FLEX_ALIGN_SPACE_EVENLY,
-                          LV_FLEX_ALIGN_END, LV_FLEX_ALIGN_CENTER);
+    lv_obj_set_flex_align(viz, LV_FLEX_ALIGN_CENTER,
+                          LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
 
-    static int heights[5] = {100, 220, 300, 220, 100};
-    for(int i = 0; i < 5; ++i) {
-        lv_obj_t* bar = lv_obj_create(viz);
-        lv_obj_remove_style_all(bar);
-        lv_obj_set_style_bg_color(bar, RED_DARK, 0);
-        lv_obj_set_style_radius(bar, 10, 0);
-        lv_obj_set_size(bar, 30, heights[i]);
-    }
+    auto make_column = [&](int count) {
+        lv_obj_t* col = lv_obj_create(viz);
+        lv_obj_remove_style_all(col);
+        lv_obj_set_size(col, LV_SIZE_CONTENT, viz_height);
+        lv_obj_set_style_pad_row(col, 4, 0);
+        lv_obj_set_layout(col, LV_LAYOUT_FLEX);
+        lv_obj_set_flex_flow(col, LV_FLEX_FLOW_COLUMN);
+        lv_obj_set_flex_align(col, LV_FLEX_ALIGN_CENTER,
+                              LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+
+        int bar_h = 10;
+        int bar_w = 30;
+        int total = count * bar_h + (count - 1) * 4;
+        int pad = (viz_height - total) / 2;
+        if(pad < 0) pad = 0;
+        lv_obj_set_style_pad_top(col, pad, 0);
+        lv_obj_set_style_pad_bottom(col, pad, 0);
+
+        for(int i = 0; i < count; ++i) {
+            lv_obj_t* bar = lv_obj_create(col);
+            lv_obj_remove_style_all(bar);
+            lv_obj_set_style_bg_color(bar, RED_DARK, 0);
+            lv_obj_set_style_radius(bar, bar_h / 2, 0);
+            lv_obj_set_size(bar, bar_w, bar_h);
+        }
+    };
+
+    make_column(19);
+    make_column(37);
+    make_column(19);
 
     // Two buttons at bottom row
     ButtonSquare* btn0 = new ButtonSquare(grid, buttons[0], 0, 1);

--- a/voice_scene.cpp
+++ b/voice_scene.cpp
@@ -30,6 +30,7 @@ lv_obj_t* create_voice_tile(lv_obj_t* tileview, int row_id, ButtonData const* bu
     lv_obj_t* viz = lv_obj_create(grid);
     lv_obj_remove_style_all(viz);
     lv_obj_set_style_bg_color(viz, BLACK, 0);
+    lv_obj_set_style_bg_opa(viz, LV_OPA_COVER, 0);
     lv_obj_set_grid_cell(viz, LV_GRID_ALIGN_STRETCH, 0, 2,
                          LV_GRID_ALIGN_STRETCH, 0, 1);
     lv_obj_set_style_pad_all(viz, 10, 0);
@@ -61,13 +62,15 @@ lv_obj_t* create_voice_tile(lv_obj_t* tileview, int row_id, ButtonData const* bu
             lv_obj_t* bar = lv_obj_create(col);
             lv_obj_remove_style_all(bar);
             lv_obj_set_style_bg_color(bar, RED_DARK, 0);
+            lv_obj_set_style_bg_opa(bar, LV_OPA_COVER, 0);
             lv_obj_set_style_radius(bar, bar_h / 2, 0);
             lv_obj_set_size(bar, bar_w, bar_h);
         }
     };
 
+    // 3 columns: outer columns 19 bars, center column 27 bars
     make_column(19);
-    make_column(37);
+    make_column(27);
     make_column(19);
 
     // Two buttons at bottom row

--- a/voice_scene.cpp
+++ b/voice_scene.cpp
@@ -1,3 +1,4 @@
+#include "voice_scene.h"
 #include "buttons.h"
 
 lv_obj_t* create_voice_tile(lv_obj_t* tileview, int row_id, ButtonData const* buttons) {

--- a/voice_scene.cpp
+++ b/voice_scene.cpp
@@ -51,7 +51,7 @@ lv_obj_t* create_voice_tile(lv_obj_t* tileview, int row_id, ButtonData const* bu
                               LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
 
         int bar_h = 10;
-        int bar_w = 30;
+        int bar_w = 100; // wider bars to fill more space
         int total = count * bar_h + (count - 1) * 4;
         int pad = (viz_height - total) / 2;
         if(pad < 0) pad = 0;
@@ -68,9 +68,9 @@ lv_obj_t* create_voice_tile(lv_obj_t* tileview, int row_id, ButtonData const* bu
         }
     };
 
-    // 3 columns: outer columns 19 bars, center column 27 bars
+    // 3 columns: outer columns 19 bars, center column 37 bars
     make_column(19);
-    make_column(27);
+    make_column(37);
     make_column(19);
 
     // Two buttons at bottom row

--- a/voice_scene.h
+++ b/voice_scene.h
@@ -1,0 +1,9 @@
+#ifndef VOICE_SCENE_H
+#define VOICE_SCENE_H
+
+#include <lvgl.h>
+#include "buttons.h"
+
+lv_obj_t* create_voice_tile(lv_obj_t* tileview, int row_id, ButtonData const* buttons);
+
+#endif


### PR DESCRIPTION
## Summary
- remove unsupported binary resources
- implement voice visualiser using rounded rectangles
- keep two control buttons under the mockup
- wire the tile into the main UI

## Testing
- `echo "No tests"`

------
https://chatgpt.com/codex/tasks/task_e_6843ce2deed08329bde866b8cb6f058a