### PR TITLE
Add USB audio playback and simple visualizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# KITT Arduino Example
+
+This example demonstrates a simple LVGL UI with button panels for the Arduino GIGA Display. The project now includes a basic audio player which loads an MP3 file from a USB flash drive.
+
+## Preparing a USB drive
+
+1. **Format the drive as FAT32.** Use your operating system's disk tool to format the 32&nbsp;GB drive as FAT32. Other filesystems may not be recognized by the Arduino GIGA.
+2. **Copy the audio file.** Place `explode.mp3` in the root directory of the drive.
+3. **Eject safely.** Unmount/eject the drive before connecting it to the board.
+
+After these steps the drive can be connected to the USB host port of the Arduino GIGA.

--- a/audio_manager.cpp
+++ b/audio_manager.cpp
@@ -1,0 +1,39 @@
+#include "audio_manager.h"
+#include <USBHost.h>
+#include <Audio.h>
+
+// USB host and mass storage objects
+static USBHost usb;
+static MassStorage ms(usb);
+static AudioPlayer player;
+static File audioFile;
+
+void audioSetup() {
+    usb.begin();
+    delay(200);
+    ms.begin();
+    player.begin();
+}
+
+bool audioPlay(const char *filename) {
+    if (audioFile) {
+        player.stop();
+        audioFile.close();
+    }
+    audioFile = ms.open(filename);
+    if (!audioFile) {
+        return false;
+    }
+    player.play(audioFile);
+    return true;
+}
+
+void audioUpdate() {
+    usb.Task();
+    player.tick();
+}
+
+float audioLevel() {
+    return player.getLevel();
+}
+

--- a/audio_manager.h
+++ b/audio_manager.h
@@ -1,0 +1,18 @@
+#ifndef AUDIO_MANAGER_H
+#define AUDIO_MANAGER_H
+
+#include <Arduino.h>
+
+// initialize USB audio playback
+void audioSetup();
+
+// play an audio file from the mounted USB drive
+bool audioPlay(const char *filename);
+
+// process audio playback tasks (call regularly in loop)
+void audioUpdate();
+
+// get current audio level 0.0-1.0 for visualizer
+float audioLevel();
+
+#endif // AUDIO_MANAGER_H

--- a/config.cpp
+++ b/config.cpp
@@ -2,6 +2,7 @@
 
 #include "buttons.h"
 #include "config.h"
+#include "audio_manager.h"
 
 void null_btn(lv_event_t *e) {
   ButtonSquare* self = static_cast<ButtonSquare*>(lv_event_get_user_data(e));
@@ -13,5 +14,13 @@ void null_btn(lv_event_t *e) {
       Serial.print("Button pressed: ");
     }
     Serial.println(self->getLabel());
+  }
+}
+
+void quote_btn(lv_event_t *e) {
+  ButtonSquare* self = static_cast<ButtonSquare*>(lv_event_get_user_data(e));
+  if (self) {
+    Serial.println("Playing quote");
+    audioPlay("explode.mp3");
   }
 }

--- a/config.h
+++ b/config.h
@@ -5,7 +5,8 @@
 
 #define BUTTON_COUNT 8
 
-void null_btn(lv_event_t *e); 
+void null_btn(lv_event_t *e);
+void quote_btn(lv_event_t *e);
 
 const ButtonData button_panel1[BUTTON_COUNT] = {
     { "TURBO BOOST", null_btn, true, 1000 },
@@ -19,7 +20,7 @@ const ButtonData button_panel1[BUTTON_COUNT] = {
 };
 
 const ButtonData button_panel2[BUTTON_COUNT] = {
-    { "BAD DOLPHINS", null_btn, true, 1000 },
+    { "QUOTE", quote_btn, false, 0 },
     { "NERVE GAS", null_btn, true, 0 },
     { "SHARKS", null_btn, false, 1000 },
     { "CUTE OTTERS", null_btn, true, 0 },

--- a/kitt.ino
+++ b/kitt.ino
@@ -7,9 +7,35 @@
 #include "buttons.h"
 #include "button_panel.h"
 #include "config.h"
+#include "audio_manager.h"
 
 GigaDisplay_GFX tft; // Init tft
 Arduino_GigaDisplayTouch TouchDetector;
+
+static lv_obj_t *voice_bars[4];
+
+static void create_voice_visualizer(lv_obj_t *parent) {
+  int spacing = 10;
+  int width = 30;
+  for (int i = 0; i < 4; ++i) {
+    voice_bars[i] = lv_obj_create(parent);
+    lv_obj_set_size(voice_bars[i], width, 10);
+    lv_obj_set_style_radius(voice_bars[i], 5, 0);
+    lv_obj_set_style_border_width(voice_bars[i], 0, 0);
+    lv_obj_set_style_bg_color(voice_bars[i], GREEN, 0);
+    lv_obj_align(voice_bars[i], LV_ALIGN_BOTTOM_MID, (i - 1.5) * (width + spacing), -20);
+  }
+}
+
+static void update_voice_visualizer(float level) {
+  if (level < 0) level = 0;
+  if (level > 1) level = 1;
+  int max_height = 60;
+  int h = 10 + (int)(level * max_height);
+  for (int i = 0; i < 4; ++i) {
+    lv_obj_set_height(voice_bars[i], h);
+  }
+}
 
 void make_panel(ButtonData const* config, lv_obj_t* tileview, int row_id) {
     auto* tile = lv_tileview_add_tile(tileview, row_id, 0, LV_DIR_HOR);
@@ -23,10 +49,14 @@ void setup() {
   lv_init(); // Initialize LVGL
   tft.begin(); // Initialize Giga Display
   TouchDetector.begin();
+  audioSetup();
+  audioPlay("explode.mp3");
 
   auto* canvas = lv_scr_act();
   lv_obj_set_style_bg_color(canvas, BLACK, 0);
-  
+
+  create_voice_visualizer(canvas);
+
   auto* tiles = lv_tileview_create(canvas);
   lv_obj_set_style_bg_color(tiles, BLACK, 0);
   lv_obj_set_scrollbar_mode(tiles, LV_SCROLLBAR_MODE_OFF);
@@ -37,5 +67,7 @@ void setup() {
 
 void loop() {
   lv_timer_handler();
+  audioUpdate();
+  update_voice_visualizer(audioLevel());
   delay(5);
 }


### PR DESCRIPTION
## Summary
- create `audio_manager` for USB audio playback and level tracking
- visualize current audio level with bars in the UI
- play `explode.mp3` at startup and when the **QUOTE** button is pressed
- document preparing the USB flash drive

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6843e16db694832998f264ee0b6fc4db