### PR TITLE
Support default active toggle buttons

### DIFF
--- a/buttons.cpp
+++ b/buttons.cpp
@@ -32,6 +32,8 @@ ButtonSquare::ButtonSquare(lv_obj_t *parent_grid, const ButtonData &data, uint8_
         }
     }
 
+    toggled = data.start_active && toggleable;
+
     lv_style_init(&style);
     lv_style_set_radius(&style, 0);
     lv_style_set_border_width(&style, 0);
@@ -43,7 +45,7 @@ ButtonSquare::ButtonSquare(lv_obj_t *parent_grid, const ButtonData &data, uint8_
 
     btn = lv_btn_create(parent_grid);
     lv_obj_add_style(btn, &style, 0);
-    lv_obj_set_style_bg_color(btn, color_off, 0);
+    lv_obj_set_style_bg_color(btn, toggled ? color_on : color_off, 0);
 
     lv_obj_set_grid_cell(btn,
         LV_GRID_ALIGN_STRETCH, grid_col, 1,

--- a/buttons.h
+++ b/buttons.h
@@ -24,6 +24,7 @@ struct ButtonData {
     button_callback callback;
     bool toggleable;
     uint16_t long_press_time; // ms, 0 = short press
+    bool start_active = false;
 };
 
 class ButtonSquare {

--- a/config.h
+++ b/config.h
@@ -8,7 +8,7 @@
 void null_btn(lv_event_t *e); 
 
 const ButtonData button_panel1[BUTTON_COUNT] = {
-    { "TURBO BOOST", null_btn, true, 1000 },
+    { "TURBO BOOST", null_btn, true, 1000, true },
     { "MAP SYSTEM", null_btn, true, 0 },
     { "SKI MODE", null_btn, false, 1000 },
     { "VOLTAGE OUTPUT", null_btn, true, 0 },
@@ -19,12 +19,12 @@ const ButtonData button_panel1[BUTTON_COUNT] = {
 };
 
 const ButtonData button_panel2[BUTTON_COUNT] = {
-    { "BAD DOLPHINS", null_btn, true, 1000 },
+    { "BAD DOLPHINS", null_btn, true, 1000, true },
     { "NERVE GAS", null_btn, true, 0 },
     { "SHARKS", null_btn, false, 1000 },
     { "CUTE OTTERS", null_btn, true, 0 },
     { "EMERGENCY METH", null_btn, false, 0 },
-    { "SCARLETT JOHANSSON", null_btn, true, 1000 },
+    { "SCARLETT JOHANSSON", null_btn, true, 1000, true },
     { "BROWNIES", null_btn, false, 0 },
     { "POT BROWNIES", null_btn, false, 0 },
 };


### PR DESCRIPTION
## Summary
- add `start_active` field to `ButtonData` for default state
- honor default state in `ButtonSquare`
- make a few red buttons begin activated

## Testing
- `g++ -std=c++17 -c buttons.cpp` *(fails: lvgl.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6845e49737ac8329add9d0a3629ee39a