### PR TITLE
Update voice tile layout

### DIFF
--- a/buttons.h
+++ b/buttons.h
@@ -14,6 +14,7 @@
 #define RED_DARK lv_color_hex(0x990000)
 #define YELLOW_DARK lv_color_hex(0x999900)
 #define ORANGE_DARK lv_color_hex(0xCC6600)
+#define GREEN_DARK lv_color_hex(0x009900)
 
 #define BLACK lv_color_hex(0x000000)
 

--- a/kitt.ino
+++ b/kitt.ino
@@ -19,9 +19,10 @@ void make_panel(ButtonData const* config, lv_obj_t* tileview, int row_id) {
     new ButtonPanel(tile, config);
 }
 
-ButtonData const voice_buttons[2] = {
+ButtonData const voice_buttons[3] = {
     { "MUTE", null_btn, false, 0 },
     { "QUOTE", null_btn, false, 0 },
+    { "OVERRIDE", null_btn, false, 0 },
 };
 
 void setup() {

--- a/kitt.ino
+++ b/kitt.ino
@@ -20,9 +20,9 @@ void make_panel(ButtonData const* config, lv_obj_t* tileview, int row_id) {
 }
 
 ButtonData const voice_buttons[3] = {
-    { "Normal Cruise", null_btn, false, 0 },
-    { "Auto Cruise", null_btn, false, 0 },
-    { "Pursuit", null_btn, false, 0 },
+    { "NORMAL CRUISE", null_btn, false, 0 },
+    { "AUTO CRUISE", null_btn, false, 0 },
+    { "PURSUIT", null_btn, false, 0 },
 };
 
 void setup() {

--- a/kitt.ino
+++ b/kitt.ino
@@ -20,9 +20,9 @@ void make_panel(ButtonData const* config, lv_obj_t* tileview, int row_id) {
 }
 
 ButtonData const voice_buttons[3] = {
-    { "MUTE", null_btn, false, 0 },
-    { "QUOTE", null_btn, false, 0 },
-    { "OVERRIDE", null_btn, false, 0 },
+    { "Normal Cruise", null_btn, false, 0 },
+    { "Auto Cruise", null_btn, false, 0 },
+    { "Pursuit", null_btn, false, 0 },
 };
 
 void setup() {

--- a/kitt.ino
+++ b/kitt.ino
@@ -39,8 +39,11 @@ void setup() {
   lv_obj_set_scrollbar_mode(tiles, LV_SCROLLBAR_MODE_OFF);
 
   make_panel(button_panel1, tiles, 0);
-  create_voice_tile(tiles, 1, voice_buttons);
+  lv_obj_t* voice_tile = create_voice_tile(tiles, 1, voice_buttons);
   make_panel(button_panel2, tiles, 2);
+
+  lv_obj_set_tile_id(tiles, 1, 0, LV_ANIM_OFF); // start on voice tile
+  LV_UNUSED(voice_tile);
 }
 
 void loop() {

--- a/voice_scene.cpp
+++ b/voice_scene.cpp
@@ -8,11 +8,11 @@ lv_obj_t* create_voice_tile(lv_obj_t* tileview, int row_id, ButtonData const* bu
     int spacing = 20;
     int circle_d = 60;
 
-    int center_width = 480 - circle_d * 2 - spacing * 4; // account for side columns and padding
-    int grid_width = 480; // full screen width
+    int center_width = (480 - circle_d * 2 - spacing * 4) * 9 / 10; // middle column 10% thinner
+    int grid_width = circle_d * 2 + center_width + spacing * 4; // recompute total width
 
     // sizing for 3 stacked buttons and remaining space for the visualizer
-    int button_h = 95; // about 2/3 the previous height
+    int button_h = 85; // 10% shorter
     int grid_height = 800;
     int viz_height = grid_height - button_h * 3 - spacing * 5;
 
@@ -22,14 +22,14 @@ lv_obj_t* create_voice_tile(lv_obj_t* tileview, int row_id, ButtonData const* bu
     lv_obj_set_size(grid, grid_width, grid_height);
     lv_obj_center(grid);
 
-    static lv_coord_t col_dsc[] = {circle_d, center_width, circle_d, LV_GRID_TEMPLATE_LAST};
-    static lv_coord_t row_dsc[] = {viz_height, button_h, button_h, button_h, LV_GRID_TEMPLATE_LAST};
+    lv_coord_t col_dsc[] = {circle_d, center_width, circle_d, LV_GRID_TEMPLATE_LAST};
+    lv_coord_t row_dsc[] = {viz_height, button_h, button_h, button_h, LV_GRID_TEMPLATE_LAST};
     lv_obj_set_grid_dsc_array(grid, col_dsc, row_dsc);
     lv_obj_set_style_pad_all(grid, spacing, 0);
     lv_obj_set_style_pad_row(grid, spacing, 0);
     lv_obj_set_style_pad_column(grid, spacing, 0);
 
-    // left and right columns of indicator circles evenly spaced vertically
+    // left and right columns of indicator lights evenly spaced vertically
     for(int side = 0; side < 2; ++side) {
         int col = side == 0 ? 0 : 2;
         lv_obj_t* column = lv_obj_create(grid);
@@ -43,12 +43,17 @@ lv_obj_t* create_voice_tile(lv_obj_t* tileview, int row_id, ButtonData const* bu
         lv_obj_set_width(column, circle_d);
 
         for(int i = 0; i < 4; ++i) {
-            lv_obj_t* circ = lv_obj_create(column);
-            lv_obj_remove_style_all(circ);
-            lv_obj_set_style_bg_opa(circ, LV_OPA_COVER, 0);
-            lv_obj_set_style_radius(circ, LV_RADIUS_CIRCLE, 0);
-            lv_obj_set_style_bg_color(circ, i < 2 ? YELLOW : RED, 0);
-            lv_obj_set_size(circ, circle_d, circle_d);
+            lv_obj_t* light = lv_obj_create(column);
+            lv_obj_remove_style_all(light);
+            lv_obj_set_style_bg_opa(light, LV_OPA_COVER, 0);
+            lv_obj_set_style_radius(light, circle_d / 2, 0);
+            lv_obj_set_style_bg_color(light, i < 2 ? YELLOW_DARK : RED_DARK, 0);
+            lv_obj_set_size(light, circle_d * 6 / 5, circle_d);
+
+            lv_obj_t* lbl = lv_label_create(light);
+            lv_obj_set_style_text_color(lbl, BLACK, 0);
+            lv_label_set_text(lbl, i < 2 ? "YL" : "RD");
+            lv_obj_center(lbl);
         }
     }
 

--- a/voice_scene.cpp
+++ b/voice_scene.cpp
@@ -6,12 +6,15 @@ lv_obj_t* create_voice_tile(lv_obj_t* tileview, int row_id, ButtonData const* bu
     lv_obj_set_style_bg_color(tile, BLACK, 0);
 
     int spacing = 20;
-    int button_size = (480 - spacing * 3) / 2; // bottom buttons width (screen width 480)
-    int grid_width = button_size * 2 + spacing * 3;
+    int circle_d = 60;
 
-    // Fill the screen height so the buttons sit at the very bottom
+    int center_width = 480 - circle_d * 2 - spacing * 4; // account for side columns and padding
+    int grid_width = 480; // full screen width
+
+    // sizing for 3 stacked buttons and remaining space for the visualizer
+    int button_h = 140;
     int grid_height = 800;
-    int viz_height = grid_height - button_size - spacing * 3;
+    int viz_height = grid_height - button_h * 3 - spacing * 5;
 
     lv_obj_t* grid = lv_obj_create(tile);
     lv_obj_remove_style_all(grid);
@@ -19,19 +22,34 @@ lv_obj_t* create_voice_tile(lv_obj_t* tileview, int row_id, ButtonData const* bu
     lv_obj_set_size(grid, grid_width, grid_height);
     lv_obj_center(grid);
 
-    static lv_coord_t col_dsc[] = {button_size, button_size, LV_GRID_TEMPLATE_LAST};
-    static lv_coord_t row_dsc[] = {viz_height, button_size, LV_GRID_TEMPLATE_LAST};
+    static lv_coord_t col_dsc[] = {circle_d, center_width, circle_d, LV_GRID_TEMPLATE_LAST};
+    static lv_coord_t row_dsc[] = {viz_height, button_h, button_h, button_h, LV_GRID_TEMPLATE_LAST};
     lv_obj_set_grid_dsc_array(grid, col_dsc, row_dsc);
     lv_obj_set_style_pad_all(grid, spacing, 0);
     lv_obj_set_style_pad_row(grid, spacing, 0);
     lv_obj_set_style_pad_column(grid, spacing, 0);
+
+    // left and right columns of indicator circles
+    for(int side = 0; side < 2; ++side) {
+        int col = side == 0 ? 0 : 2;
+        for(int i = 0; i < 4; ++i) {
+            lv_obj_t* circ = lv_obj_create(grid);
+            lv_obj_remove_style_all(circ);
+            lv_obj_set_style_bg_opa(circ, LV_OPA_COVER, 0);
+            lv_obj_set_style_radius(circ, LV_RADIUS_CIRCLE, 0);
+            lv_obj_set_style_bg_color(circ, i < 2 ? YELLOW : RED, 0);
+            lv_obj_set_size(circ, circle_d, circle_d);
+            lv_obj_set_grid_cell(circ, LV_GRID_ALIGN_CENTER, col, 1,
+                                 LV_GRID_ALIGN_CENTER, i, 1);
+        }
+    }
 
     // Visualizer mockup using three columns of rounded rectangles
     lv_obj_t* viz = lv_obj_create(grid);
     lv_obj_remove_style_all(viz);
     lv_obj_set_style_bg_color(viz, BLACK, 0);
     lv_obj_set_style_bg_opa(viz, LV_OPA_COVER, 0);
-    lv_obj_set_grid_cell(viz, LV_GRID_ALIGN_STRETCH, 0, 2,
+    lv_obj_set_grid_cell(viz, LV_GRID_ALIGN_STRETCH, 1, 1,
                          LV_GRID_ALIGN_STRETCH, 0, 1);
     lv_obj_set_style_pad_all(viz, 10, 0);
     lv_obj_set_style_pad_column(viz, 15, 0);
@@ -51,7 +69,7 @@ lv_obj_t* create_voice_tile(lv_obj_t* tileview, int row_id, ButtonData const* bu
                               LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
 
         int bar_h = 10;
-        int bar_w = 100; // wider bars to fill more space
+        int bar_w = (center_width - 50) / 3; // fit within the smaller visualizer
         int total = count * bar_h + (count - 1) * 4;
         int pad = (viz_height - total) / 2;
         if(pad < 0) pad = 0;
@@ -73,12 +91,14 @@ lv_obj_t* create_voice_tile(lv_obj_t* tileview, int row_id, ButtonData const* bu
     make_column(37);
     make_column(19);
 
-    // Two buttons at bottom row
-    ButtonSquare* btn0 = new ButtonSquare(grid, buttons[0], 0, 1);
-    ButtonSquare* btn1 = new ButtonSquare(grid, buttons[1], 1, 1);
+    // Three stacked buttons in the centre column
+    ButtonSquare* btn0 = new ButtonSquare(grid, buttons[0], 1, 1);
+    ButtonSquare* btn1 = new ButtonSquare(grid, buttons[1], 1, 2);
+    ButtonSquare* btn2 = new ButtonSquare(grid, buttons[2], 1, 3);
 
     LV_UNUSED(btn0); // avoid unused warnings if compiled
     LV_UNUSED(btn1);
+    LV_UNUSED(btn2);
 
     return tile;
 }

--- a/voice_scene.cpp
+++ b/voice_scene.cpp
@@ -31,7 +31,7 @@ lv_obj_t* create_voice_tile(lv_obj_t* tileview, int row_id, ButtonData const* bu
     lv_obj_set_style_pad_column(grid, spacing, 0);
 
     // left and right columns of indicator lights evenly spaced vertically
-    static const char* left_labels[4] = {"Air", "OIL", "P1", "P2"};
+    static const char* left_labels[4] = {"AIR", "OIL", "P1", "P2"};
     static const char* right_labels[4] = {"S1", "S2", "P3", "P4"};
     for(int side = 0; side < 2; ++side) {
         int col = side == 0 ? 0 : 2;

--- a/voice_scene.cpp
+++ b/voice_scene.cpp
@@ -7,9 +7,10 @@ lv_obj_t* create_voice_tile(lv_obj_t* tileview, int row_id, ButtonData const* bu
 
     int spacing = 20;
     int circle_d = 60;
+    int column_w = circle_d * 6 / 5; // wider so lights aren't clipped
 
-    int center_width = (480 - circle_d * 2 - spacing * 4) * 9 / 10; // middle column 10% thinner
-    int grid_width = circle_d * 2 + center_width + spacing * 4; // recompute total width
+    int center_width = (480 - circle_d * 2 - spacing * 4) * 9 / 10; // keep middle column width
+    int grid_width = column_w * 2 + center_width + spacing * 4; // recompute total width
 
     // sizing for 3 stacked buttons and remaining space for the visualizer
     int button_h = 85; // 10% shorter
@@ -22,7 +23,7 @@ lv_obj_t* create_voice_tile(lv_obj_t* tileview, int row_id, ButtonData const* bu
     lv_obj_set_size(grid, grid_width, grid_height);
     lv_obj_center(grid);
 
-    static lv_coord_t col_dsc[] = {circle_d, center_width, circle_d, LV_GRID_TEMPLATE_LAST};
+    static lv_coord_t col_dsc[] = {column_w, center_width, column_w, LV_GRID_TEMPLATE_LAST};
     static lv_coord_t row_dsc[] = {viz_height, button_h, button_h, button_h, LV_GRID_TEMPLATE_LAST};
     lv_obj_set_grid_dsc_array(grid, col_dsc, row_dsc);
     lv_obj_set_style_pad_all(grid, spacing, 0);
@@ -40,7 +41,7 @@ lv_obj_t* create_voice_tile(lv_obj_t* tileview, int row_id, ButtonData const* bu
         lv_obj_set_flex_flow(column, LV_FLEX_FLOW_COLUMN);
         lv_obj_set_flex_align(column, LV_FLEX_ALIGN_SPACE_EVENLY,
                               LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
-        lv_obj_set_width(column, circle_d);
+        lv_obj_set_width(column, column_w);
 
         for(int i = 0; i < 4; ++i) {
             lv_obj_t* light = lv_obj_create(column);
@@ -99,9 +100,9 @@ lv_obj_t* create_voice_tile(lv_obj_t* tileview, int row_id, ButtonData const* bu
         }
     };
 
-    // 3 columns: outer columns 19 bars, center column 37 bars
+    // 3 columns: outer columns 19 bars, center column shortened to 33 bars
     make_column(19);
-    make_column(37);
+    make_column(33);
     make_column(19);
 
     // Three stacked buttons in the centre column

--- a/voice_scene.cpp
+++ b/voice_scene.cpp
@@ -22,8 +22,8 @@ lv_obj_t* create_voice_tile(lv_obj_t* tileview, int row_id, ButtonData const* bu
     lv_obj_set_size(grid, grid_width, grid_height);
     lv_obj_center(grid);
 
-    lv_coord_t col_dsc[] = {circle_d, center_width, circle_d, LV_GRID_TEMPLATE_LAST};
-    lv_coord_t row_dsc[] = {viz_height, button_h, button_h, button_h, LV_GRID_TEMPLATE_LAST};
+    static lv_coord_t col_dsc[] = {circle_d, center_width, circle_d, LV_GRID_TEMPLATE_LAST};
+    static lv_coord_t row_dsc[] = {viz_height, button_h, button_h, button_h, LV_GRID_TEMPLATE_LAST};
     lv_obj_set_grid_dsc_array(grid, col_dsc, row_dsc);
     lv_obj_set_style_pad_all(grid, spacing, 0);
     lv_obj_set_style_pad_row(grid, spacing, 0);

--- a/voice_scene.cpp
+++ b/voice_scene.cpp
@@ -12,7 +12,7 @@ lv_obj_t* create_voice_tile(lv_obj_t* tileview, int row_id, ButtonData const* bu
     int grid_width = 480; // full screen width
 
     // sizing for 3 stacked buttons and remaining space for the visualizer
-    int button_h = 140;
+    int button_h = 95; // about 2/3 the previous height
     int grid_height = 800;
     int viz_height = grid_height - button_h * 3 - spacing * 5;
 
@@ -29,18 +29,26 @@ lv_obj_t* create_voice_tile(lv_obj_t* tileview, int row_id, ButtonData const* bu
     lv_obj_set_style_pad_row(grid, spacing, 0);
     lv_obj_set_style_pad_column(grid, spacing, 0);
 
-    // left and right columns of indicator circles
+    // left and right columns of indicator circles evenly spaced vertically
     for(int side = 0; side < 2; ++side) {
         int col = side == 0 ? 0 : 2;
+        lv_obj_t* column = lv_obj_create(grid);
+        lv_obj_remove_style_all(column);
+        lv_obj_set_grid_cell(column, LV_GRID_ALIGN_CENTER, col, 1,
+                             LV_GRID_ALIGN_STRETCH, 0, 4);
+        lv_obj_set_layout(column, LV_LAYOUT_FLEX);
+        lv_obj_set_flex_flow(column, LV_FLEX_FLOW_COLUMN);
+        lv_obj_set_flex_align(column, LV_FLEX_ALIGN_SPACE_EVENLY,
+                              LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+        lv_obj_set_width(column, circle_d);
+
         for(int i = 0; i < 4; ++i) {
-            lv_obj_t* circ = lv_obj_create(grid);
+            lv_obj_t* circ = lv_obj_create(column);
             lv_obj_remove_style_all(circ);
             lv_obj_set_style_bg_opa(circ, LV_OPA_COVER, 0);
             lv_obj_set_style_radius(circ, LV_RADIUS_CIRCLE, 0);
             lv_obj_set_style_bg_color(circ, i < 2 ? YELLOW : RED, 0);
             lv_obj_set_size(circ, circle_d, circle_d);
-            lv_obj_set_grid_cell(circ, LV_GRID_ALIGN_CENTER, col, 1,
-                                 LV_GRID_ALIGN_CENTER, i, 1);
         }
     }
 

--- a/voice_scene.cpp
+++ b/voice_scene.cpp
@@ -31,6 +31,8 @@ lv_obj_t* create_voice_tile(lv_obj_t* tileview, int row_id, ButtonData const* bu
     lv_obj_set_style_pad_column(grid, spacing, 0);
 
     // left and right columns of indicator lights evenly spaced vertically
+    static const char* left_labels[4] = {"Air", "OIL", "P1", "P2"};
+    static const char* right_labels[4] = {"S1", "S2", "P3", "P4"};
     for(int side = 0; side < 2; ++side) {
         int col = side == 0 ? 0 : 2;
         lv_obj_t* column = lv_obj_create(grid);
@@ -53,7 +55,7 @@ lv_obj_t* create_voice_tile(lv_obj_t* tileview, int row_id, ButtonData const* bu
 
             lv_obj_t* lbl = lv_label_create(light);
             lv_obj_set_style_text_color(lbl, BLACK, 0);
-            lv_label_set_text(lbl, i < 2 ? "YL" : "RD");
+            lv_label_set_text(lbl, side == 0 ? left_labels[i] : right_labels[i]);
             lv_obj_center(lbl);
         }
     }
@@ -100,9 +102,9 @@ lv_obj_t* create_voice_tile(lv_obj_t* tileview, int row_id, ButtonData const* bu
         }
     };
 
-    // 3 columns: outer columns 19 bars, center column shortened to 33 bars
+    // 3 columns: outer columns 19 bars, center column shortened to 29 bars
     make_column(19);
-    make_column(33);
+    make_column(29);
     make_column(19);
 
     // Three stacked buttons in the centre column


### PR DESCRIPTION
## Summary
- revamp middle voice tile layout
- add third voice button and shrink visualizer
- add `GREEN_DARK` color for dimmed state

## Testing
- `arduino-cli compile --fqbn arduino:avr:uno` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845e7cf38b48329b92ce7940f370925