### PR TITLE
Add override color constructor and update voice buttons

### DIFF
--- a/buttons.cpp
+++ b/buttons.cpp
@@ -58,6 +58,43 @@ ButtonSquare::ButtonSquare(lv_obj_t *parent_grid, const ButtonData &data, uint8_
     lv_obj_add_event_cb(btn, btn_event_cb, LV_EVENT_ALL, this);
 }
 
+ButtonSquare::ButtonSquare(lv_obj_t *parent_grid, const ButtonData &data, uint8_t grid_col, uint8_t grid_row,
+                           lv_color_t override_off, lv_color_t override_on)
+    : label(data.label), callback(data.callback), toggleable(data.toggleable)
+    , long_press_time(data.long_press_time)
+{
+    Serial.print("Creating ButtonSquare: ");
+    Serial.println(label);
+
+    color_off = override_off;
+    color_on = override_on;
+
+    toggled = data.start_active && toggleable;
+
+    lv_style_init(&style);
+    lv_style_set_radius(&style, 0);
+    lv_style_set_border_width(&style, 0);
+    lv_style_set_shadow_width(&style, 0);
+    lv_style_set_outline_width(&style, 0);
+    lv_style_set_pad_all(&style, 0);
+    lv_style_set_text_color(&style, BLACK);
+    lv_style_set_text_font(&style, &lv_font_montserrat_14);
+
+    btn = lv_btn_create(parent_grid);
+    lv_obj_add_style(btn, &style, 0);
+    lv_obj_set_style_bg_color(btn, toggled ? color_on : color_off, 0);
+
+    lv_obj_set_grid_cell(btn,
+        LV_GRID_ALIGN_STRETCH, grid_col, 1,
+        LV_GRID_ALIGN_STRETCH, grid_row, 1);
+
+    label_obj = lv_label_create(btn);
+    lv_label_set_text(label_obj, label);
+    lv_obj_center(label_obj);
+
+    lv_obj_add_event_cb(btn, btn_event_cb, LV_EVENT_ALL, this);
+}
+
 void ButtonSquare::handlePress() {
     if (toggleable) {
         toggled = !toggled;

--- a/buttons.h
+++ b/buttons.h
@@ -9,12 +9,16 @@
 #define YELLOW lv_color_hex(0xFFFF00)
 #define ORANGE lv_color_hex(0xFF8800)
 #define GREEN lv_color_hex(0x00FF00)
+// new blue variant
+#define BLUE lv_color_hex(0x0077FF)
 
 // dark variants for toggled-off states
 #define RED_DARK lv_color_hex(0x990000)
 #define YELLOW_DARK lv_color_hex(0x999900)
 #define ORANGE_DARK lv_color_hex(0xCC6600)
 #define GREEN_DARK lv_color_hex(0x009900)
+// dark blue
+#define BLUE_DARK lv_color_hex(0x0033AA)
 
 #define BLACK lv_color_hex(0x000000)
 
@@ -31,6 +35,8 @@ struct ButtonData {
 class ButtonSquare {
 public:
     ButtonSquare(lv_obj_t *parent_grid, const ButtonData &data, uint8_t grid_col, uint8_t grid_row);
+    ButtonSquare(lv_obj_t *parent_grid, const ButtonData &data, uint8_t grid_col, uint8_t grid_row,
+                 lv_color_t color_off, lv_color_t color_on);
     void handlePress();
     void updateVisual();
     void eventHandler(lv_event_t* e);

--- a/kitt.ino
+++ b/kitt.ino
@@ -20,9 +20,9 @@ void make_panel(ButtonData const* config, lv_obj_t* tileview, int row_id) {
 }
 
 ButtonData const voice_buttons[3] = {
-    { "NORMAL CRUISE", null_btn, false, 0 },
-    { "AUTO CRUISE", null_btn, false, 0 },
-    { "PURSUIT", null_btn, false, 0 },
+    { "NORMAL CRUISE", null_btn, true, 0 },
+    { "AUTO CRUISE", null_btn, true, 0 },
+    { "PURSUIT", null_btn, true, 0 },
 };
 
 void setup() {

--- a/kitt.ino
+++ b/kitt.ino
@@ -20,9 +20,9 @@ void make_panel(ButtonData const* config, lv_obj_t* tileview, int row_id) {
 }
 
 ButtonData const voice_buttons[3] = {
-    { "NORMAL CRUISE", null_btn, true, 0 },
-    { "AUTO CRUISE", null_btn, true, 0 },
-    { "PURSUIT", null_btn, true, 0 },
+    { "NORMAL CRUISE", null_btn, true, 1000 },
+    { "AUTO CRUISE", null_btn, true, 1000 },
+    { "PURSUIT", null_btn, true, 1000 },
 };
 
 void setup() {

--- a/voice_scene.cpp
+++ b/voice_scene.cpp
@@ -107,10 +107,10 @@ lv_obj_t* create_voice_tile(lv_obj_t* tileview, int row_id, ButtonData const* bu
     make_column(29);
     make_column(19);
 
-    // Three stacked buttons in the centre column
-    ButtonSquare* btn0 = new ButtonSquare(grid, buttons[0], 1, 1);
-    ButtonSquare* btn1 = new ButtonSquare(grid, buttons[1], 1, 2);
-    ButtonSquare* btn2 = new ButtonSquare(grid, buttons[2], 1, 3);
+    // Three stacked buttons in the centre column with custom colours
+    ButtonSquare* btn0 = new ButtonSquare(grid, buttons[0], 1, 1, GREEN_DARK, GREEN);
+    ButtonSquare* btn1 = new ButtonSquare(grid, buttons[1], 1, 2, ORANGE_DARK, ORANGE);
+    ButtonSquare* btn2 = new ButtonSquare(grid, buttons[2], 1, 3, BLUE_DARK, BLUE);
 
     LV_UNUSED(btn0); // avoid unused warnings if compiled
     LV_UNUSED(btn1);


### PR DESCRIPTION
## Summary
- add BLUE and BLUE_DARK color macros
- support explicit color overrides via new `ButtonSquare` constructor
- make voice tile buttons toggleable and give them color overrides

## Testing
- `g++ -std=c++17 -c buttons.cpp -I.` *(fails: lvgl.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6845f33acb508329ab51b54fa8b08c4a