### PR TITLE
Refactor button and indicator styles

### DIFF
--- a/button.cpp
+++ b/button.cpp
@@ -34,28 +34,7 @@ Button::Button(lv_obj_t *parent_grid, const ButtonData &data, uint8_t grid_col, 
 
     toggled = data.start_active && toggleable;
 
-    lv_style_init(&style);
-    lv_style_set_radius(&style, 0);
-    lv_style_set_border_width(&style, 0);
-    lv_style_set_shadow_width(&style, 0);
-    lv_style_set_outline_width(&style, 0);
-    lv_style_set_pad_all(&style, 0);
-    lv_style_set_text_color(&style, BLACK);
-    lv_style_set_text_font(&style, &lv_font_montserrat_14);
-
-    btn = lv_btn_create(parent_grid);
-    lv_obj_add_style(btn, &style, 0);
-    lv_obj_set_style_bg_color(btn, toggled ? color_on : color_off, 0);
-
-    lv_obj_set_grid_cell(btn,
-        LV_GRID_ALIGN_STRETCH, grid_col, 1,
-        LV_GRID_ALIGN_STRETCH, grid_row, 1);
-
-    label_obj = lv_label_create(btn);
-    lv_label_set_text(label_obj, label);
-    lv_obj_center(label_obj);
-
-    lv_obj_add_event_cb(btn, btn_event_cb, LV_EVENT_ALL, this);
+    createButton(parent_grid, grid_col, grid_row);
 }
 
 Button::Button(lv_obj_t *parent_grid, const ButtonData &data, uint8_t grid_col, uint8_t grid_row,
@@ -71,28 +50,7 @@ Button::Button(lv_obj_t *parent_grid, const ButtonData &data, uint8_t grid_col, 
 
     toggled = data.start_active && toggleable;
 
-    lv_style_init(&style);
-    lv_style_set_radius(&style, 0);
-    lv_style_set_border_width(&style, 0);
-    lv_style_set_shadow_width(&style, 0);
-    lv_style_set_outline_width(&style, 0);
-    lv_style_set_pad_all(&style, 0);
-    lv_style_set_text_color(&style, BLACK);
-    lv_style_set_text_font(&style, &lv_font_montserrat_14);
-
-    btn = lv_btn_create(parent_grid);
-    lv_obj_add_style(btn, &style, 0);
-    lv_obj_set_style_bg_color(btn, toggled ? color_on : color_off, 0);
-
-    lv_obj_set_grid_cell(btn,
-        LV_GRID_ALIGN_STRETCH, grid_col, 1,
-        LV_GRID_ALIGN_STRETCH, grid_row, 1);
-
-    label_obj = lv_label_create(btn);
-    lv_label_set_text(label_obj, label);
-    lv_obj_center(label_obj);
-
-    lv_obj_add_event_cb(btn, btn_event_cb, LV_EVENT_ALL, this);
+    createButton(parent_grid, grid_col, grid_row);
 }
 
 void Button::handlePress() {
@@ -140,4 +98,29 @@ void Button::eventHandler(lv_event_t* e) {
     } else if (code == LV_EVENT_CLICKED && long_press_time == 0) {
         handlePress();
     }
+}
+
+void Button::createButton(lv_obj_t *parent_grid, uint8_t grid_col, uint8_t grid_row) {
+    lv_style_init(&style);
+    lv_style_set_radius(&style, 0);
+    lv_style_set_border_width(&style, 0);
+    lv_style_set_shadow_width(&style, 0);
+    lv_style_set_outline_width(&style, 0);
+    lv_style_set_pad_all(&style, 0);
+    lv_style_set_text_color(&style, BLACK);
+    lv_style_set_text_font(&style, &lv_font_montserrat_14);
+
+    btn = lv_btn_create(parent_grid);
+    lv_obj_add_style(btn, &style, 0);
+    lv_obj_set_style_bg_color(btn, toggled ? color_on : color_off, 0);
+
+    lv_obj_set_grid_cell(btn,
+        LV_GRID_ALIGN_STRETCH, grid_col, 1,
+        LV_GRID_ALIGN_STRETCH, grid_row, 1);
+
+    label_obj = lv_label_create(btn);
+    lv_label_set_text(label_obj, label);
+    lv_obj_center(label_obj);
+
+    lv_obj_add_event_cb(btn, btn_event_cb, LV_EVENT_ALL, this);
 }

--- a/button.h
+++ b/button.h
@@ -45,6 +45,8 @@ private:
 
     bool toggleable;
     bool toggled = false;
+
+    void createButton(lv_obj_t *parent_grid, uint8_t grid_col, uint8_t grid_row);
 };
 
 #endif

--- a/indicator.cpp
+++ b/indicator.cpp
@@ -3,6 +3,14 @@
 #include "config.h"
 
 Indicator::Indicator(const IndicatorData& data, lv_obj_t* parent) : data(data) {
+    createIndicator(parent);
+}
+
+void Indicator::toggle(bool on) {
+    lv_obj_set_style_bg_color(this->indicator, on ? data.light : data.dark, 0);
+}
+
+void Indicator::createIndicator(lv_obj_t* parent) {
     lv_obj_t* indicator = lv_obj_create(parent);
     lv_obj_remove_style_all(indicator);
     lv_obj_set_style_bg_opa(indicator, LV_OPA_COVER, 0);
@@ -14,10 +22,6 @@ Indicator::Indicator(const IndicatorData& data, lv_obj_t* parent) : data(data) {
     lv_obj_set_style_text_color(lbl, BLACK, 0);
     lv_label_set_text(lbl, data.label);
     lv_obj_center(lbl);
-    
-    this->indicator = indicator;
-}
 
-void Indicator::toggle(bool on) {
-    lv_obj_set_style_bg_color(this->indicator, on ? data.light : data.dark, 0);
+    this->indicator = indicator;
 }

--- a/indicator.h
+++ b/indicator.h
@@ -13,6 +13,8 @@ class Indicator {
     const IndicatorData& data;
     lv_obj_t* indicator;
 
+    void createIndicator(lv_obj_t* parent);
+
 public:
     Indicator(const IndicatorData& data, lv_obj_t* parent);
     void toggle(bool on);


### PR DESCRIPTION
## Summary
- extract `createButton` and `createIndicator` to centralize UI styling
- call the new helpers from constructors

## Testing
- `make test` *(fails: No rule to make target `test`)*

------
https://chatgpt.com/codex/tasks/task_e_6846190a55b8832985d1dc719bdc3d30