### PR TITLE
Add severe flag for long hold buttons

### DIFF
--- a/button.cpp
+++ b/button.cpp
@@ -8,14 +8,14 @@ static void btn_event_cb(lv_event_t * e) {
 
 Button::Button(lv_obj_t *parent_grid, const ButtonData &data, uint8_t grid_col, uint8_t grid_row)
     : label(data.label), callback(data.callback), toggleable(data.toggleable)
-    , long_press_time(data.long_press_time)
+    , severe(data.severe)
 {
     Serial.print("Creating Button: ");
     Serial.println(label);
     
     // determine colors based on behaviour
     if (toggleable) {
-        if (long_press_time > 0) { // red
+        if (severe) { // red
             color_off = RED_DARK;
             color_on = RED;
         } else { // yellow
@@ -23,7 +23,7 @@ Button::Button(lv_obj_t *parent_grid, const ButtonData &data, uint8_t grid_col, 
             color_on = YELLOW;
         }
     } else {
-        if (long_press_time > 0) { // orange
+        if (severe) { // orange
             color_off = ORANGE;
             color_on = ORANGE;
         } else { // green
@@ -54,7 +54,7 @@ Button::Button(lv_obj_t *parent_grid, const ButtonData &data, uint8_t grid_col, 
 Button::Button(lv_obj_t *parent_grid, const ButtonData &data, uint8_t grid_col, uint8_t grid_row,
                            lv_color_t override_off, lv_color_t override_on)
     : label(data.label), callback(data.callback), toggleable(data.toggleable)
-    , long_press_time(data.long_press_time)
+    , severe(data.severe)
 {
     Serial.print("Creating Button: ");
     Serial.println(label);
@@ -108,13 +108,13 @@ void Button::eventHandler(lv_event_t* e) {
     if (code == LV_EVENT_PRESSED) {
         press_start = millis();
         long_press_handled = false;
-    } else if (code == LV_EVENT_PRESSING && long_press_time > 0) {
+    } else if (code == LV_EVENT_PRESSING && severe) {
         if (!long_press_handled) {
             uint32_t elapsed = millis() - press_start;
-            lv_opa_t ratio = elapsed >= long_press_time ? 255 : (255 * elapsed / long_press_time);
+            lv_opa_t ratio = elapsed >= LONG_PRESS_DURATION ? 255 : (255 * elapsed / LONG_PRESS_DURATION);
             lv_color_t base = toggleable ? (toggled ? color_on : color_off) : color_off;
             lv_obj_set_style_bg_color(btn, lv_color_mix(WHITE, base, ratio), 0);
-            if (elapsed >= long_press_time) {
+            if (elapsed >= LONG_PRESS_DURATION) {
                 handlePress();
                 long_press_handled = true;
                 if (!toggleable)
@@ -123,7 +123,7 @@ void Button::eventHandler(lv_event_t* e) {
         }
     } else if (code == LV_EVENT_RELEASED || code == LV_EVENT_PRESS_LOST) {
         updateVisual();
-    } else if (code == LV_EVENT_CLICKED && long_press_time == 0) {
+    } else if (code == LV_EVENT_CLICKED && !severe) {
         handlePress();
     }
 }

--- a/button.h
+++ b/button.h
@@ -10,7 +10,7 @@ struct ButtonData {
     const char *label;
     button_callback callback;
     bool toggleable;
-    uint16_t long_press_time; // ms, 0 = short press
+    bool severe = false; // hold for one second before triggering if true
     bool start_active = false;
 };
 
@@ -41,7 +41,8 @@ private:
     lv_color_t color_off;
     lv_color_t color_on;
 
-    uint16_t long_press_time = 0;
+    static const uint16_t LONG_PRESS_DURATION = 1000; // ms
+    bool severe = false;
     uint32_t press_start = 0;
     bool long_press_handled = false;
 

--- a/config.h
+++ b/config.h
@@ -10,25 +10,25 @@
 void null_btn(lv_event_t *e); 
 
 const ButtonData button_panel1[BUTTON_COUNT] = {
-    { "TURBO BOOST", null_btn, true, 1000, true },
-    { "MAP SYSTEM", null_btn, true, 0 },
-    { "SKI MODE", null_btn, false, 1000 },
-    { "VOLTAGE OUTPUT", null_btn, true, 0 },
-    { "VITAL SCAN", null_btn, false, 0 },
-    { "EVADE", null_btn, false, 0 },
-    { "RANGE BRITE", null_btn, false, 0 },
-    { "RADAR IMAGE", null_btn, false, 0 },
+    { "TURBO BOOST", null_btn, true, true, true },
+    { "MAP SYSTEM", null_btn, true, false },
+    { "SKI MODE", null_btn, false, true },
+    { "VOLTAGE OUTPUT", null_btn, true, false },
+    { "VITAL SCAN", null_btn, false, false },
+    { "EVADE", null_btn, false, false },
+    { "RANGE BRITE", null_btn, false, false },
+    { "RADAR IMAGE", null_btn, false, false },
 };
 
 const ButtonData button_panel2[BUTTON_COUNT] = {
-    { "BAD DOLPHINS", null_btn, true, 1000, true },
-    { "NERVE GAS", null_btn, true, 0 },
-    { "SHARKS", null_btn, false, 1000 },
-    { "CUTE OTTERS", null_btn, true, 0 },
-    { "EMERGENCY METH", null_btn, false, 0 },
-    { "SCARLETT JOHANSSON", null_btn, true, 1000, true },
-    { "BROWNIES", null_btn, false, 0 },
-    { "POT BROWNIES", null_btn, false, 0 },
+    { "BAD DOLPHINS", null_btn, true, true, true },
+    { "NERVE GAS", null_btn, true, false },
+    { "SHARKS", null_btn, false, true },
+    { "CUTE OTTERS", null_btn, true, false },
+    { "EMERGENCY METH", null_btn, false, false },
+    { "SCARLETT JOHANSSON", null_btn, true, true, true },
+    { "BROWNIES", null_btn, false, false },
+    { "POT BROWNIES", null_btn, false, false },
 };
 
 // VIZ DATA

--- a/kitt.ino
+++ b/kitt.ino
@@ -24,9 +24,9 @@ void make_panel(ButtonData const* config, lv_obj_t* tileview, int row_id) {
 }
 
 ButtonData const voice_buttons[3] = {
-    { "AUTO CRUISE", null_btn, true, 1000 },
-    { "NORMAL CRUISE", null_btn, true, 1000 },
-    { "PURSUIT", null_btn, true, 1000 },
+    { "AUTO CRUISE", null_btn, true, true },
+    { "NORMAL CRUISE", null_btn, true, true },
+    { "PURSUIT", null_btn, true, true },
 };
 
 void setup() {


### PR DESCRIPTION
## Summary
- switch ButtonData `long_press_time` to boolean `severe`
- handle severe buttons with a 1 second hold requirement
- update button colors and arrays for the new flag
- default `severe` to false

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_e_68466fb69b808329927c5fe632f41ee9