### PR TITLE
Add timer-based voice visualiser animation

### DIFF
--- a/kitt.ino
+++ b/kitt.ino
@@ -4,6 +4,7 @@
 #include <Arduino_GigaDisplayTouch.h>
 #include <Arduino_GigaDisplay_GFX.h>
 #include <lvgl.h>
+#include <math.h>
 
 #include "button.h"
 #include "button_panel.h"
@@ -17,6 +18,16 @@ VoiceTile *voiceTile = nullptr;
 Button *motor_btn = nullptr;
 Button *btn24v = nullptr;
 Button *inverter_btn = nullptr;
+lv_timer_t *voice_anim_timer = nullptr;
+
+static void voice_anim_cb(lv_timer_t *t) {
+  static uint32_t step = 0;
+  (void)t;
+  float val = (sin(step * 0.1f) + 1.0f) / 2.0f;
+  if (voiceTile && voiceTile->getVisualiser())
+    voiceTile->getVisualiser()->setLevel(val);
+  step++;
+}
 
 void setup() {
   Serial.begin(115200); // Initialize Serial
@@ -54,6 +65,8 @@ void setup() {
   }
 
   lv_obj_set_tile_id(tiles, 1, 0, LV_ANIM_OFF); // start on voice tile
+
+  voice_anim_timer = lv_timer_create(voice_anim_cb, 50, nullptr);
 
   // audio_setup();
 }

--- a/voice_tile.cpp
+++ b/voice_tile.cpp
@@ -42,8 +42,8 @@ VoiceTile::VoiceTile(lv_obj_t *tileview, int row_id,
 
   visualiser = new VoiceVisualiser(grid);
 
-  // debug
-  visualiser->set_cols_active(5.0f / 16);
+  // start with no volume
+  visualiser->setLevel(0.0f);
   this->indicators[0]->toggle(true);
   this->indicators[2]->toggle(true);
 

--- a/voice_visualiser.cpp
+++ b/voice_visualiser.cpp
@@ -19,6 +19,8 @@ VoiceVisualiser::VoiceVisualiser(lv_obj_t *parent) {
   make_column(0, 19);
   make_column(1, 29);
   make_column(2, 19);
+
+  timer = lv_timer_create(timer_cb, 50, this); // 20 FPS update
 }
 
 void VoiceVisualiser::make_column(int id, int count) {
@@ -75,4 +77,19 @@ void VoiceVisualiser::set_cols_active(float ratio_norm) {
       }
     }
   }
+}
+
+void VoiceVisualiser::setLevel(float lvl) {
+  if (lvl < 0.f)
+    lvl = 0.f;
+  if (lvl > 1.f)
+    lvl = 1.f;
+  level = lvl;
+}
+
+void VoiceVisualiser::timer_cb(lv_timer_t *t) {
+  auto self = static_cast<VoiceVisualiser *>(t->user_data);
+  if (!self)
+    return;
+  self->set_cols_active(self->level);
 }

--- a/voice_visualiser.h
+++ b/voice_visualiser.h
@@ -8,11 +8,16 @@ class VoiceVisualiser {
   lv_obj_t *cols[3];
   int col_count[3];
 
+  lv_timer_t *timer = nullptr;
+  float level = 0.f; // normalised 0..1 value
+
   void make_column(int id, int count);
+  static void timer_cb(lv_timer_t *t);
 
 public:
   VoiceVisualiser(lv_obj_t *parent);
   void set_cols_active(float ratio_norm);
+  void setLevel(float lvl);
 };
 
 #endif


### PR DESCRIPTION
## Summary
- add timer and level setter to `VoiceVisualiser`
- start with zero volume on `VoiceTile`
- drive voice visualisation from a periodic timer in `kitt.ino`

## Testing
- `arduino-cli version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847547aa9248329881343bbde88cb19