### PR TITLE
Add gauge component and tile

### DIFF
--- a/UI.cpp
+++ b/UI.cpp
@@ -5,11 +5,13 @@
 #include "config.h"
 #include "voice_synth.h"
 #include "voice_tile.h"
+#include "gauge_tile.h"
 
 UI ui;
 
 // Global UI element pointers defined here
 VoiceTile *voiceTile = nullptr;
+GaugeTile *gaugeTile = nullptr;
 Button *motor_btn = nullptr;
 Button *btn24v = nullptr;
 Button *inverter_btn = nullptr;
@@ -31,6 +33,7 @@ void UI::init() {
       btn->setCallback(voice_mode_cb);
   }
   rightPanel = ButtonPanel::createTile(tiles, 2, button_panel2);
+  gaugeTile = new GaugeTile(tiles, 3);
   motor_btn = rightPanel->getButton(0);
   if (motor_btn) {
     motor_btn->setCallback(motor_override_cb);

--- a/UI.h
+++ b/UI.h
@@ -5,6 +5,7 @@
 
 class ButtonPanel;
 class VoiceTile;
+class GaugeTile;
 
 class UI {
   lv_obj_t *canvas = nullptr;
@@ -12,6 +13,7 @@ class UI {
   ButtonPanel *leftPanel = nullptr;
   VoiceTile *voiceTile = nullptr;
   ButtonPanel *rightPanel = nullptr;
+  GaugeTile *gaugeTile = nullptr;
   lv_timer_t *voice_anim_timer = nullptr;
 
 public:
@@ -19,6 +21,7 @@ public:
   VoiceTile *getVoiceTile() const { return voiceTile; }
   ButtonPanel *getLeftPanel() const { return leftPanel; }
   ButtonPanel *getRightPanel() const { return rightPanel; }
+  GaugeTile *getGaugeTile() const { return gaugeTile; }
 };
 
 extern UI ui;

--- a/config.h
+++ b/config.h
@@ -51,6 +51,15 @@ const ButtonData voice_buttons[3] = {
 #define BUTTON_HEIGHT 85
 #define VISUALISER_HEIGHT (GRID_HEIGHT - BUTTON_HEIGHT * 3 - SPACING * 5)
 
+// ==== Gauge configuration ====
+#define GAUGE_SEG_COUNT 10
+#define GAUGE_SEG_W 20
+#define GAUGE_SEG_H 10
+#define GAUGE_SPACING 4
+#define GAUGE_WIDTH                                                            \
+  (GAUGE_SEG_COUNT * GAUGE_SEG_W + (GAUGE_SEG_COUNT - 1) * GAUGE_SPACING)
+#define GAUGE_HEIGHT GAUGE_SEG_H * 2
+
 static const IndicatorData indicators[8] = {
     {"AIR", ORANGE_DARK, ORANGE}, {"OIL", ORANGE_DARK, ORANGE},
     {"P1", RED_DARK, RED},        {"P2", RED_DARK, RED},
@@ -59,8 +68,10 @@ static const IndicatorData indicators[8] = {
 
 // ==== Global UI references ====
 class VoiceTile;
+class GaugeTile;
 
 extern VoiceTile *voiceTile;
+extern GaugeTile *gaugeTile;
 extern Button *motor_btn;
 extern Button *btn24v;
 extern Button *inverter_btn;

--- a/gauge.cpp
+++ b/gauge.cpp
@@ -1,0 +1,60 @@
+#include "gauge.h"
+
+const lv_color_t Gauge::dark_colors[GAUGE_SEG_COUNT] = {
+    GREEN_DARK, GREEN_DARK, GREEN_DARK, GREEN_DARK,
+    YELLOW_DARK, YELLOW_DARK, YELLOW_DARK,
+    RED_DARK, RED_DARK, RED_DARK};
+
+const lv_color_t Gauge::lit_colors[GAUGE_SEG_COUNT] = {
+    GREEN, GREEN, GREEN, GREEN,
+    YELLOW, YELLOW, YELLOW,
+    RED, RED, RED};
+
+Gauge::Gauge(lv_obj_t *parent, const char *text) {
+  container = lv_obj_create(parent);
+  lv_obj_remove_style_all(container);
+  lv_obj_set_layout(container, LV_LAYOUT_GRID);
+  static lv_coord_t col_dsc[] = {GAUGE_WIDTH, 60, LV_GRID_TEMPLATE_LAST};
+  static lv_coord_t row_dsc[] = {GAUGE_HEIGHT, LV_GRID_TEMPLATE_LAST};
+  lv_obj_set_grid_dsc_array(container, col_dsc, row_dsc);
+  lv_obj_set_size(container, GAUGE_WIDTH + 60, GAUGE_HEIGHT);
+
+  lv_obj_t *bar_cont = lv_obj_create(container);
+  lv_obj_remove_style_all(bar_cont);
+  lv_obj_set_grid_cell(bar_cont, LV_GRID_ALIGN_START, 0, 1,
+                       LV_GRID_ALIGN_CENTER, 0, 1);
+  lv_obj_set_layout(bar_cont, LV_LAYOUT_FLEX);
+  lv_obj_set_flex_flow(bar_cont, LV_FLEX_FLOW_ROW);
+  lv_obj_set_flex_align(bar_cont, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_CENTER,
+                        LV_FLEX_ALIGN_CENTER);
+  lv_obj_set_style_pad_column(bar_cont, GAUGE_SPACING, 0);
+
+  for (int i = 0; i < GAUGE_SEG_COUNT; ++i) {
+    lv_obj_t *bar = lv_obj_create(bar_cont);
+    lv_obj_remove_style_all(bar);
+    lv_obj_set_style_bg_color(bar, dark_colors[i], 0);
+    lv_obj_set_style_bg_opa(bar, LV_OPA_COVER, 0);
+    lv_obj_set_size(bar, GAUGE_SEG_W, GAUGE_SEG_H * 2);
+    bars[i] = bar;
+  }
+
+  label = lv_label_create(container);
+  lv_obj_set_grid_cell(label, LV_GRID_ALIGN_END, 1, 1,
+                       LV_GRID_ALIGN_CENTER, 0, 1);
+  lv_label_set_text(label, text);
+  lv_obj_set_style_text_color(label, WHITE, 0);
+  lv_obj_set_style_text_font(label, &lv_font_montserrat_14, 0);
+  lv_obj_set_style_text_align(label, LV_TEXT_ALIGN_RIGHT, 0);
+}
+
+void Gauge::setLevel(float level) {
+  if (level < 0.f)
+    level = 0.f;
+  if (level > 1.f)
+    level = 1.f;
+  int lit = (int)(level * GAUGE_SEG_COUNT + 0.5f);
+  for (int i = 0; i < GAUGE_SEG_COUNT; ++i) {
+    lv_color_t col = i < lit ? lit_colors[i] : dark_colors[i];
+    lv_obj_set_style_bg_color(bars[i], col, 0);
+  }
+}

--- a/gauge.h
+++ b/gauge.h
@@ -1,0 +1,22 @@
+#ifndef GAUGE_H
+#define GAUGE_H
+
+#include <lvgl.h>
+#include "colors.h"
+#include "config.h"
+
+class Gauge {
+  lv_obj_t *container;
+  lv_obj_t *bars[GAUGE_SEG_COUNT];
+  lv_obj_t *label;
+
+  static const lv_color_t dark_colors[GAUGE_SEG_COUNT];
+  static const lv_color_t lit_colors[GAUGE_SEG_COUNT];
+
+public:
+  Gauge(lv_obj_t *parent, const char *text);
+  lv_obj_t *getContainer() const { return container; }
+  void setLevel(float level); // level normalized 0..1
+};
+
+#endif

--- a/gauge_tile.cpp
+++ b/gauge_tile.cpp
@@ -1,0 +1,39 @@
+#include "gauge_tile.h"
+#include "config.h"
+
+static const char *gauge_labels[6] = {
+    "G1", "G2", "G3", "G4", "G5", "G6"};
+
+GaugeTile::GaugeTile(lv_obj_t *tileview, int row_id) {
+  tile = lv_tileview_add_tile(tileview, row_id, 0, LV_DIR_HOR);
+  lv_obj_set_style_bg_color(tile, BLACK, 0);
+
+  lv_obj_t *grid = lv_obj_create(tile);
+  lv_obj_remove_style_all(grid);
+  lv_obj_set_layout(grid, LV_LAYOUT_GRID);
+  lv_obj_set_size(grid, GRID_HEIGHT, 480); // treat as landscape grid
+  lv_obj_center(grid);
+
+  static lv_coord_t col_dsc[] = {LV_GRID_FR(1), LV_GRID_FR(1), LV_GRID_TEMPLATE_LAST};
+  static lv_coord_t row_dsc[] = {LV_GRID_FR(1), LV_GRID_FR(1), LV_GRID_FR(1), LV_GRID_TEMPLATE_LAST};
+  lv_obj_set_grid_dsc_array(grid, col_dsc, row_dsc);
+  lv_obj_set_style_pad_all(grid, SPACING, 0);
+  lv_obj_set_style_pad_row(grid, SPACING, 0);
+  lv_obj_set_style_pad_column(grid, SPACING, 0);
+
+  int idx = 0;
+  for (int col = 0; col < 2; ++col) {
+    for (int row = 0; row < 3; ++row) {
+      gauges[idx] = new Gauge(grid, gauge_labels[idx]);
+      lv_obj_set_grid_cell(gauges[idx]->getContainer(), LV_GRID_ALIGN_CENTER, col, 1,
+                           LV_GRID_ALIGN_CENTER, row, 1);
+      idx++;
+    }
+  }
+}
+
+GaugeTile::~GaugeTile() {
+  for (auto &g : gauges) {
+    delete g;
+  }
+}

--- a/gauge_tile.h
+++ b/gauge_tile.h
@@ -1,0 +1,18 @@
+#ifndef GAUGE_TILE_H
+#define GAUGE_TILE_H
+
+#include "gauge.h"
+#include <lvgl.h>
+
+class GaugeTile {
+  lv_obj_t *tile;
+  Gauge *gauges[6];
+
+public:
+  GaugeTile(lv_obj_t *tileview, int row_id);
+  lv_obj_t *getTile() const { return tile; }
+  Gauge *getGauge(int idx) const { return (idx >= 0 && idx < 6) ? gauges[idx] : nullptr; }
+  ~GaugeTile();
+};
+
+#endif


### PR DESCRIPTION
## Summary
- add gauge component that displays 4 green, 3 yellow and 3 red bars
- make a gauge tile with six gauges arranged in a landscape style grid
- integrate the new tile into the UI and expose it via config

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6847632c66cc83299bea5666ca2dc209