### PR TITLE
Prevent disabling active voice mode

### DIFF
--- a/UI.cpp
+++ b/UI.cpp
@@ -36,8 +36,10 @@ void UI::init() {
   ::voiceTile = voiceTile;
   for (int i = 0; i < 3; ++i) {
     Button *btn = voiceTile->getButton(i);
-    if (btn)
+    if (btn) {
       btn->setCallback(voice_mode_cb);
+      btn->setValidate(validate_voice_mode);
+    }
   }
   rightPanel = ButtonPanel::createTile(tiles, 3, button_panel2);
 

--- a/config.cpp
+++ b/config.cpp
@@ -91,3 +91,8 @@ bool validate_inverter(lv_event_t *e) {
   }
   return true;
 }
+
+bool validate_voice_mode(lv_event_t *e) {
+  auto self = static_cast<Button *>(lv_event_get_user_data(e));
+  return !(self && self->isToggled());
+}

--- a/config.h
+++ b/config.h
@@ -74,5 +74,6 @@ void voice_mode_cb(lv_event_t *e);
 bool validate_24v(lv_event_t *e);
 bool validate_motor(lv_event_t *e);
 bool validate_inverter(lv_event_t *e);
+bool validate_voice_mode(lv_event_t *e);
 
 #endif


### PR DESCRIPTION
## Summary
- keep only one voice mode button active at a time
- add `validate_voice_mode` to block user from turning off the active voice mode
- apply the validator to AUTO CRUISE, NORMAL CRUISE, and PURSUIT buttons

## Testing
- `arduino-cli version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847c0d693308329b93d4e6f180e4ed8