### PR TITLE
Implement display blackout feature

### DIFF
--- a/UI.cpp
+++ b/UI.cpp
@@ -25,6 +25,7 @@ void UI::init() {
   tiles = lv_tileview_create(canvas);
   lv_obj_set_style_bg_color(tiles, BLACK, 0);
   lv_obj_set_scrollbar_mode(tiles, LV_SCROLLBAR_MODE_OFF);
+  lv_obj_add_event_cb(tiles, blackout_touch_cb, LV_EVENT_PRESSED, nullptr);
 
   static const char *const left_labels[] = {"RPM", "MOTOR CURRENT",
                                             "PERIPHERAL CURRENT"};
@@ -42,6 +43,10 @@ void UI::init() {
     }
   }
   rightPanel = ButtonPanel::createTile(tiles, 3, button_panel2);
+  blackout_btn = rightPanel->getButton(1);
+  if (blackout_btn) {
+    blackout_btn->setCallback(blackout_cb);
+  }
 
   static const char *const right_labels[] = {"BATTERY VOLTAGE",
                                              "BATTERY CURRENT",

--- a/UI.cpp
+++ b/UI.cpp
@@ -45,7 +45,7 @@ void UI::init() {
   rightPanel = ButtonPanel::createTile(tiles, 3, button_panel2);
   blackout_btn = rightPanel->getButton(1);
   if (blackout_btn) {
-    blackout_btn->setCallback(blackout_cb);
+    blackout_btn->setCallback(blackout_btn_cb);
   }
 
   static const char *const right_labels[] = {"BATTERY VOLTAGE",

--- a/config.cpp
+++ b/config.cpp
@@ -96,3 +96,31 @@ bool validate_voice_mode(lv_event_t *e) {
   auto self = static_cast<Button *>(lv_event_get_user_data(e));
   return !(self && self->isToggled());
 }
+
+Button *blackout_btn = nullptr;
+
+void turnDisplayOff() { analogWrite(BACKLIGHT_PIN, 0); }
+
+void turnDisplayOn() { analogWrite(BACKLIGHT_PIN, 255); }
+
+void blackout_cb(lv_event_t *e) {
+  Button *self = static_cast<Button *>(lv_event_get_user_data(e));
+  if (!self)
+    return;
+  if (self->isToggled()) {
+    turnDisplayOff();
+  } else {
+    turnDisplayOn();
+  }
+}
+
+void blackout_touch_cb(lv_event_t *e) {
+  if (!blackout_btn || !blackout_btn->isToggled())
+    return;
+  if (lv_event_get_target(e) == blackout_btn->getLVButton())
+    return;
+  if (lv_event_get_code(e) == LV_EVENT_PRESSED) {
+    blackout_btn->handlePress();
+    turnDisplayOn();
+  }
+}

--- a/config.cpp
+++ b/config.cpp
@@ -99,18 +99,21 @@ bool validate_voice_mode(lv_event_t *e) {
 
 Button *blackout_btn = nullptr;
 
-void turnDisplayOff() { analogWrite(BACKLIGHT_PIN, 0); }
+static bool backlight_enabled = true;
 
-void turnDisplayOn() { analogWrite(BACKLIGHT_PIN, 255); }
+void set_backlight(bool on) {
+  analogWrite(BACKLIGHT_PIN, on ? 255 : 0);
+  backlight_enabled = on;
+}
 
-void blackout_cb(lv_event_t *e) {
+void blackout_btn_cb(lv_event_t *e) {
   Button *self = static_cast<Button *>(lv_event_get_user_data(e));
   if (!self)
     return;
   if (self->isToggled()) {
-    turnDisplayOff();
+    set_backlight(false);
   } else {
-    turnDisplayOn();
+    set_backlight(true);
   }
 }
 
@@ -121,6 +124,6 @@ void blackout_touch_cb(lv_event_t *e) {
     return;
   if (lv_event_get_code(e) == LV_EVENT_PRESSED) {
     blackout_btn->handlePress();
-    turnDisplayOn();
+    set_backlight(true);
   }
 }

--- a/config.h
+++ b/config.h
@@ -67,6 +67,13 @@ extern GaugeTile *leftGaugeTile;
 extern Button *motor_btn;
 extern Button *btn24v;
 extern Button *inverter_btn;
+extern Button *blackout_btn;
+
+#define BACKLIGHT_PIN D9
+void turnDisplayOff();
+void turnDisplayOn();
+void blackout_cb(lv_event_t *e);
+void blackout_touch_cb(lv_event_t *e);
 
 // ==== Event callbacks ====
 void motor_override_cb(lv_event_t *e);

--- a/config.h
+++ b/config.h
@@ -70,9 +70,9 @@ extern Button *inverter_btn;
 extern Button *blackout_btn;
 
 #define BACKLIGHT_PIN D9
-void turnDisplayOff();
-void turnDisplayOn();
-void blackout_cb(lv_event_t *e);
+
+void set_backlight(bool on);
+void blackout_btn_cb(lv_event_t *e);
 void blackout_touch_cb(lv_event_t *e);
 
 // ==== Event callbacks ====

--- a/kitt.ino
+++ b/kitt.ino
@@ -20,6 +20,9 @@ void setup() {
   tft.begin();          // Initialize Giga Display
   TouchDetector.begin();
 
+  pinMode(BACKLIGHT_PIN, OUTPUT);
+  turnDisplayOn();
+
   ui.init();
 
   // audio_setup();

--- a/kitt.ino
+++ b/kitt.ino
@@ -21,7 +21,7 @@ void setup() {
   TouchDetector.begin();
 
   pinMode(BACKLIGHT_PIN, OUTPUT);
-  turnDisplayOn();
+  set_backlight(true);
 
   ui.init();
 


### PR DESCRIPTION
## Summary
- allow setting backlight brightness
- register blackout touch handler and button callback
- control display power via BLACKOUT button
- ensure backlight starts enabled

## Testing
- `echo "No tests"`

------
https://chatgpt.com/codex/tasks/task_e_6847c28bab388329a97822671b99c05a