### PR TITLE
Add blackout callback

### DIFF
--- a/UI.cpp
+++ b/UI.cpp
@@ -15,6 +15,7 @@ VoiceTile *voiceTile = nullptr;
 GaugeTile *gaugeTile = nullptr;
 GaugeTile *leftGaugeTile = nullptr;
 Button *motor_btn = nullptr;
+Button *blackout_btn = nullptr;
 Button *btn24v = nullptr;
 Button *inverter_btn = nullptr;
 
@@ -54,6 +55,10 @@ void UI::init() {
   if (motor_btn) {
     motor_btn->setCallback(motor_override_cb);
     motor_btn->setValidate(validate_motor);
+  }
+  blackout_btn = rightPanel->getButton(1);
+  if (blackout_btn) {
+    blackout_btn->setCallback(blackout_cb);
   }
   btn24v = rightPanel->getButton(2);
   if (btn24v) {

--- a/config.cpp
+++ b/config.cpp
@@ -26,6 +26,17 @@ void motor_override_cb(lv_event_t *e) {
   Serial.println("MOTOR override callback!");
 }
 
+void blackout_cb(lv_event_t *e) {
+  auto self = static_cast<Button *>(lv_event_get_user_data(e));
+  if (!self)
+    return;
+  if (self->isToggled()) {
+    Serial.println("BLACKOUT engaged");
+  } else {
+    Serial.println("BLACKOUT disengaged");
+  }
+}
+
 void voice_mode_cb(lv_event_t *e) {
   auto self = static_cast<Button *>(lv_event_get_user_data(e));
   if (!self || !self->isToggled() || !voiceTile)

--- a/config.h
+++ b/config.h
@@ -65,11 +65,13 @@ extern VoiceTile *voiceTile;
 extern GaugeTile *gaugeTile;
 extern GaugeTile *leftGaugeTile;
 extern Button *motor_btn;
+extern Button *blackout_btn;
 extern Button *btn24v;
 extern Button *inverter_btn;
 
 // ==== Event callbacks ====
 void motor_override_cb(lv_event_t *e);
+void blackout_cb(lv_event_t *e);
 void voice_mode_cb(lv_event_t *e);
 bool validate_24v(lv_event_t *e);
 bool validate_motor(lv_event_t *e);


### PR DESCRIPTION
## Summary
- add `blackout_btn` pointer and connect the new callback
- implement `blackout_cb` with on/off logic
- expose callback and button in `config.h`

## Testing
- `pytest -q`
- `make test` *(fails: No rule to make target)*

------
https://chatgpt.com/codex/tasks/task_e_6847c66c2f488329ad150f0571827316