### PR TITLE
Implement screen blackout mode

### DIFF
--- a/config.cpp
+++ b/config.cpp
@@ -32,8 +32,14 @@ void blackout_cb(lv_event_t *e) {
     return;
   if (self->isToggled()) {
     Serial.println("BLACKOUT engaged");
+    blackout = true;
+    blackout_released = false;
+    backlight.set(0); // turn off backlight
   } else {
     Serial.println("BLACKOUT disengaged");
+    blackout = false;
+    blackout_released = false;
+    backlight.set(255); // restore brightness
   }
 }
 

--- a/config.h
+++ b/config.h
@@ -3,6 +3,7 @@
 
 #include "button.h"
 #include "indicator.h"
+#include <Arduino_GigaDisplay.h>
 
 // ==== Layout constants ====
 #define SPACING 20
@@ -68,6 +69,9 @@ extern Button *motor_btn;
 extern Button *blackout_btn;
 extern Button *btn24v;
 extern Button *inverter_btn;
+extern bool blackout;
+extern bool blackout_released;
+extern GigaDisplayBacklight backlight;
 
 // ==== Event callbacks ====
 void motor_override_cb(lv_event_t *e);

--- a/kitt.ino
+++ b/kitt.ino
@@ -3,6 +3,7 @@
 #include "audio_helper.h"
 #include <Arduino_GigaDisplayTouch.h>
 #include <Arduino_GigaDisplay_GFX.h>
+#include <Arduino_GigaDisplay.h>
 #include <lvgl.h>
 #include <math.h>
 
@@ -13,12 +14,19 @@
 
 GigaDisplay_GFX tft; // Init tft
 Arduino_GigaDisplayTouch TouchDetector;
+GigaDisplayBacklight backlight;
+bool blackout = false;
+bool blackout_released = false;
+static bool release_pending = false;
+static uint32_t release_start = 0;
+static const uint32_t RELEASE_THRESHOLD = 150; // ms
 
 void setup() {
   Serial.begin(115200); // Initialize Serial
   lv_init();            // Initialize LVGL
   tft.begin();          // Initialize Giga Display
   TouchDetector.begin();
+  backlight.begin();
 
   ui.init();
 
@@ -28,4 +36,27 @@ void setup() {
 void loop() {
   lv_timer_handler();
   // audio_loop();
+
+  if (blackout) {
+    GDTpoint_t points[GT911_MAX_CONTACTS];
+    uint8_t contacts = TouchDetector.getTouchPoints(points);
+    if (contacts == 0) {
+      if (!release_pending) {
+        release_pending = true;
+        release_start = millis();
+      } else if (millis() - release_start > RELEASE_THRESHOLD) {
+        blackout_released = true;
+      }
+    } else {
+      release_pending = false;
+      if (blackout_released) {
+        blackout = false;
+        blackout_released = false;
+        backlight.set(255);
+        if (blackout_btn && blackout_btn->isToggled()) {
+          blackout_btn->handlePress();
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- control display brightness with GigaDisplayBacklight
- track blackout state in `kitt.ino`
- turn screen off/on in `blackout_cb`
- restore screen when touched while in blackout mode
- require a touch release before exiting blackout
- debounce release detection to stop flicker

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_e_6847ccfdafc883298a9c567806bdd778