### PR TITLE
Fix scroll flags

### DIFF
--- a/gauge.cpp
+++ b/gauge.cpp
@@ -5,6 +5,9 @@
 Gauge::Gauge(lv_obj_t *parent, const char *label) {
   container = lv_obj_create(parent);
   lv_obj_remove_style_all(container);
+  // Ensure the gauge container itself doesn't scroll
+  lv_obj_clear_flag(container, LV_OBJ_FLAG_SCROLLABLE);
+  lv_obj_set_scrollbar_mode(container, LV_SCROLLBAR_MODE_OFF);
   lv_obj_set_layout(container, LV_LAYOUT_FLEX);
   lv_obj_set_flex_flow(container, LV_FLEX_FLOW_COLUMN);
   // Place children from the top of the container so the label appears above
@@ -39,6 +42,9 @@ Gauge::Gauge(lv_obj_t *parent, const char *label) {
 
   lv_obj_t *row = lv_obj_create(container);
   lv_obj_remove_style_all(row);
+  // Prevent scrolling within the row of bars
+  lv_obj_clear_flag(row, LV_OBJ_FLAG_SCROLLABLE);
+  lv_obj_set_scrollbar_mode(row, LV_SCROLLBAR_MODE_OFF);
   lv_obj_set_layout(row, LV_LAYOUT_FLEX);
   lv_obj_set_flex_flow(row, LV_FLEX_FLOW_ROW);
   // Align the row's children from left to right but keep them anchored to the
@@ -54,6 +60,7 @@ Gauge::Gauge(lv_obj_t *parent, const char *label) {
   for (int n = 0; n < 10; ++n) {
     lv_obj_t *bar = lv_obj_create(row);
     lv_obj_remove_style_all(bar);
+    lv_obj_clear_flag(bar, LV_OBJ_FLAG_SCROLLABLE);
     lv_obj_set_style_radius(bar, 3, 0);
     lv_obj_set_size(bar, w, h);
     lv_obj_set_style_bg_opa(bar, LV_OPA_COVER, 0);

--- a/gauge_tile.cpp
+++ b/gauge_tile.cpp
@@ -9,9 +9,15 @@ GaugeTile::GaugeTile(lv_obj_t *tileview, int row_id, const char *const *labels,
     : gauge_count(count), display(nullptr) {
   tile = lv_tileview_add_tile(tileview, row_id, 0, LV_DIR_HOR);
   lv_obj_set_style_bg_color(tile, BLACK, 0);
+  // Prevent the tile itself from scrolling
+  lv_obj_clear_flag(tile, LV_OBJ_FLAG_SCROLLABLE);
+  lv_obj_set_scrollbar_mode(tile, LV_SCROLLBAR_MODE_OFF);
 
   lv_obj_t *container = lv_obj_create(tile);
   lv_obj_remove_style_all(container);
+  // Disable scrolling within the container
+  lv_obj_clear_flag(container, LV_OBJ_FLAG_SCROLLABLE);
+  lv_obj_set_scrollbar_mode(container, LV_SCROLLBAR_MODE_OFF);
   lv_obj_set_size(container, GRID_WIDTH, GRID_HEIGHT);
   lv_obj_center(container);
   lv_obj_set_layout(container, LV_LAYOUT_FLEX);
@@ -24,6 +30,8 @@ GaugeTile::GaugeTile(lv_obj_t *tileview, int row_id, const char *const *labels,
   if (with_display) {
     display = new SevenSegmentDisplay(container);
     // Leave extra space after the display so the gauges sit lower
+    lv_obj_clear_flag(display->getObj(), LV_OBJ_FLAG_SCROLLABLE);
+    lv_obj_set_scrollbar_mode(display->getObj(), LV_SCROLLBAR_MODE_OFF);
     lv_obj_set_style_pad_bottom(display->getObj(), SPACING * 2, 0);
   }
 

--- a/voice_tile.cpp
+++ b/voice_tile.cpp
@@ -5,9 +5,15 @@ VoiceTile::VoiceTile(lv_obj_t *tileview, int row_id,
                      ButtonData const *button_data) {
   tile = lv_tileview_add_tile(tileview, row_id, 0, LV_DIR_HOR);
   lv_obj_set_style_bg_color(tile, BLACK, 0);
+  // Tile itself shouldn't be scrollable
+  lv_obj_clear_flag(tile, LV_OBJ_FLAG_SCROLLABLE);
+  lv_obj_set_scrollbar_mode(tile, LV_SCROLLBAR_MODE_OFF);
 
   lv_obj_t *grid = lv_obj_create(tile);
   lv_obj_remove_style_all(grid);
+  // Disable scrolling inside the grid container
+  lv_obj_clear_flag(grid, LV_OBJ_FLAG_SCROLLABLE);
+  lv_obj_set_scrollbar_mode(grid, LV_SCROLLBAR_MODE_OFF);
   lv_obj_set_layout(grid, LV_LAYOUT_GRID);
   lv_obj_set_size(grid, GRID_WIDTH, GRID_HEIGHT);
   lv_obj_center(grid);
@@ -26,6 +32,9 @@ VoiceTile::VoiceTile(lv_obj_t *tileview, int row_id,
     int col = side == 0 ? 0 : 2;
     lv_obj_t *column = lv_obj_create(grid);
     lv_obj_remove_style_all(column);
+    // Keep columns fixed in place
+    lv_obj_clear_flag(column, LV_OBJ_FLAG_SCROLLABLE);
+    lv_obj_set_scrollbar_mode(column, LV_SCROLLBAR_MODE_OFF);
     lv_obj_set_grid_cell(column, LV_GRID_ALIGN_CENTER, col, 1,
                          LV_GRID_ALIGN_STRETCH, 0, 4);
     lv_obj_set_layout(column, LV_LAYOUT_FLEX);

--- a/voice_visualiser.cpp
+++ b/voice_visualiser.cpp
@@ -5,6 +5,9 @@
 VoiceVisualiser::VoiceVisualiser(lv_obj_t *parent) {
   viz = lv_obj_create(parent);
   lv_obj_remove_style_all(viz);
+  // Prevent scrolling of the visualiser container
+  lv_obj_clear_flag(viz, LV_OBJ_FLAG_SCROLLABLE);
+  lv_obj_set_scrollbar_mode(viz, LV_SCROLLBAR_MODE_OFF);
   lv_obj_set_style_bg_color(viz, BLACK, 0);
   lv_obj_set_style_bg_opa(viz, LV_OPA_COVER, 0);
   lv_obj_set_grid_cell(viz, LV_GRID_ALIGN_STRETCH, 1, 1, LV_GRID_ALIGN_STRETCH,
@@ -26,6 +29,9 @@ VoiceVisualiser::VoiceVisualiser(lv_obj_t *parent) {
 void VoiceVisualiser::make_column(int id, int count) {
   lv_obj_t *col = lv_obj_create(viz);
   lv_obj_remove_style_all(col);
+  // Columns should also remain fixed
+  lv_obj_clear_flag(col, LV_OBJ_FLAG_SCROLLABLE);
+  lv_obj_set_scrollbar_mode(col, LV_SCROLLBAR_MODE_OFF);
   lv_obj_set_size(col, LV_SIZE_CONTENT, VISUALISER_HEIGHT);
   lv_obj_set_style_pad_row(col, 4, 0);
   lv_obj_set_layout(col, LV_LAYOUT_FLEX);
@@ -45,6 +51,8 @@ void VoiceVisualiser::make_column(int id, int count) {
   for (int i = 0; i < count; ++i) {
     lv_obj_t *bar = lv_obj_create(col);
     lv_obj_remove_style_all(bar);
+    lv_obj_clear_flag(bar, LV_OBJ_FLAG_SCROLLABLE);
+    lv_obj_set_scrollbar_mode(bar, LV_SCROLLBAR_MODE_OFF);
     lv_obj_set_style_bg_color(bar, RED_DARK, 0);
     lv_obj_set_style_bg_opa(bar, LV_OPA_COVER, 0);
     lv_obj_set_style_radius(bar, bar_h / 2, 0);


### PR DESCRIPTION
## Summary
- disable scrolling and hide scroll bars on gauge containers and bar rows
- stop gauge tiles and internal containers from scrolling
- ensure voice tile layout and voice visualiser stay fixed
- prevent all visualiser columns and bars from scrolling

## Testing
- `arduino-cli compile ./kitt.ino` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847dc2ef34c83298b82f37e1f2aeff1