### PR TITLE
Graceful fallback if USB audio missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Ensure the board package and all libraries are up to date in the Arduino IDE or 
 
 After uploading, the device starts on the center voice tile. Swipe left or right to access the button panels.
 
-Audio files (`*.wav`) are stored in the `data` folder for reference. They can be copied to a USB drive connected to the board if you wish to enable the audio helper.
+Audio files (`*.wav`) are stored in the `data` folder for reference. They can be copied to a USB drive connected to the board if you wish to enable the audio helper. If no USB storage is detected at runtime the sketch simply runs without audio.
 
 ## License
 

--- a/audio_helper.cpp
+++ b/audio_helper.cpp
@@ -8,6 +8,7 @@ static const char *audio_files[] = {"intro.wav", "explode.wav", "shoe.wav"};
 static const int audio_file_count =
     sizeof(audio_files) / sizeof(audio_files[0]);
 static int current_audio_index = 0;
+static bool audio_enabled = false;
 
 static bool load_current_audio() {
   if (!audio.load(const_cast<char *>(audio_files[current_audio_index]))) {
@@ -25,16 +26,28 @@ static bool load_current_audio() {
 void audio_setup() {
   current_audio_index = 0;
   if (load_current_audio()) {
+    audio_enabled = true;
     audio.play();
+  } else {
+    audio_enabled = false;
+    Serial.println("USB drive not found - audio disabled");
   }
 }
 
 void audio_loop() {
+  if (!audio_enabled)
+    return;
+
   if (audio.isFinished()) {
     current_audio_index = (current_audio_index + 1) % audio_file_count;
     if (load_current_audio()) {
       audio.play();
       Serial.println("Restarting . . .");
+    } else {
+      audio_enabled = false;
+      Serial.println("Audio playback failed - disabling audio");
     }
   }
 }
+
+bool audio_is_enabled() { return audio_enabled; }

--- a/audio_helper.h
+++ b/audio_helper.h
@@ -3,5 +3,6 @@
 
 void audio_setup();
 void audio_loop();
+bool audio_is_enabled();
 
 #endif


### PR DESCRIPTION
## Summary
- disable audio playback when USB storage isn't present
- expose a helper to query audio status
- document USB audio fallback behavior in README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68486409dfd88329aacf9c2dd95be346