### PR TITLE
Gracefully disable audio if USB missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ It is currently used to experiment with a fun control panel for an augmented gol
   * **Left panel** – button grid in the KITT style.
   * **Center panel** – voice synthesiser display with indicators (default view).
   * **Right panel** – secondary button grid for practical controls.
-* Basic audio playback support from USB (see `audio_helper.*`).
+* Basic audio playback support from USB (see `audio_helper.*`). If no USB drive
+  is detected at startup, the rest of the demo runs without attempting to play
+  audio.
 
 The `ref` directory contains screenshots used for layout reference.
 

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ It is currently used to experiment with a fun control panel for an augmented gol
   * **Left panel** – button grid in the KITT style.
   * **Center panel** – voice synthesiser display with indicators (default view).
   * **Right panel** – secondary button grid for practical controls.
-* Basic audio playback support from USB (see `audio_helper.*`). If no USB drive
-  is detected at startup, the rest of the demo runs without attempting to play
-  audio.
+* Basic audio playback support from USB (see `audio_helper.*`). On startup the
+  code waits briefly for a USB drive to appear. If none is found, the rest of the
+  demo runs without attempting to play audio.
 
 The `ref` directory contains screenshots used for layout reference.
 

--- a/audio_helper.cpp
+++ b/audio_helper.cpp
@@ -4,6 +4,7 @@
 #include <GigaAudio.h>
 
 static GigaAudio audio("USB DISK");
+static bool audio_enabled = false;
 static const char *audio_files[] = {"intro.wav", "explode.wav", "shoe.wav", "joseph.wav"};
 static const int audio_file_count =
     sizeof(audio_files) / sizeof(audio_files[0]);
@@ -26,10 +27,16 @@ void audio_setup() {
   current_audio_index = 0;
   if (load_current_audio()) {
     audio.play();
+    audio_enabled = true;
+  } else {
+    audio_enabled = false;
+    Serial.println("USB drive not found - audio disabled");
   }
 }
 
 void audio_loop() {
+  if (!audio_enabled)
+    return;
   if (audio.isFinished()) {
     current_audio_index = (current_audio_index + 1) % audio_file_count;
     if (load_current_audio()) {

--- a/audio_helper.cpp
+++ b/audio_helper.cpp
@@ -23,15 +23,22 @@ static bool load_current_audio() {
   return true;
 }
 
-void audio_setup() {
+bool audio_setup(unsigned long timeout_ms) {
   current_audio_index = 0;
-  if (load_current_audio()) {
-    audio.play();
-    audio_enabled = true;
-  } else {
-    audio_enabled = false;
-    Serial.println("USB drive not found - audio disabled");
+  unsigned long start = millis();
+
+  while (millis() - start < timeout_ms) {
+    if (load_current_audio()) {
+      audio.play();
+      audio_enabled = true;
+      return true;
+    }
+    delay(100);
   }
+
+  audio_enabled = false;
+  Serial.println("USB drive not found - audio disabled");
+  return false;
 }
 
 void audio_loop() {

--- a/audio_helper.h
+++ b/audio_helper.h
@@ -1,7 +1,7 @@
 #ifndef AUDIO_HELPER_H
 #define AUDIO_HELPER_H
 
-void audio_setup();
+bool audio_setup(unsigned long timeout_ms = 3000);
 void audio_loop();
 
 #endif

--- a/kitt.ino
+++ b/kitt.ino
@@ -16,6 +16,7 @@ GigaDisplay_GFX tft; // Init tft
 Arduino_GigaDisplayTouch TouchDetector;
 GigaDisplayBacklight backlight;
 bool blackout = false;
+static bool audio_ready = false;
 
 void setup() {
   Serial.begin(115200); // Initialize Serial
@@ -26,11 +27,12 @@ void setup() {
 
   ui.init();
 
-  audio_setup();
+  audio_ready = audio_setup();
 }
 
 void loop() {
   lv_timer_handler();
   
-  audio_loop();
+  if (audio_ready)
+    audio_loop();
 }

--- a/kitt.ino
+++ b/kitt.ino
@@ -16,7 +16,7 @@ GigaDisplay_GFX tft; // Init tft
 Arduino_GigaDisplayTouch TouchDetector;
 GigaDisplayBacklight backlight;
 bool blackout = false;
-static bool audio_ready = false;
+static bool audio_enabled = false;
 
 void setup() {
   Serial.begin(115200); // Initialize Serial
@@ -27,12 +27,12 @@ void setup() {
 
   ui.init();
 
-  audio_ready = audio_setup();
+  audio_enabled = audio_setup();
 }
 
 void loop() {
   lv_timer_handler();
-  
-  if (audio_ready)
+
+  if (audio_enabled)
     audio_loop();
 }


### PR DESCRIPTION
## Summary
- handle absence of a USB drive by disabling audio
- document audio fallback behavior in README

## Testing
- `g++ -c audio_helper.cpp` *(fails: Arduino.h not found)*

------
https://chatgpt.com/codex/tasks/task_e_684865848d5c832995afbcbaa9b50391