### PR TITLE
Gracefully handle audio load failures

### DIFF
--- a/audio_helper.cpp
+++ b/audio_helper.cpp
@@ -10,16 +10,24 @@ static const int audio_file_count =
 static int current_audio_index = 0;
 
 static bool load_current_audio() {
-  if (!audio.load(const_cast<char *>(audio_files[current_audio_index]))) {
+  int attempts = 0;
+  while (attempts < audio_file_count) {
+    if (audio.load(const_cast<char *>(audio_files[current_audio_index]))) {
+      return true;
+    }
+
     if (audio.hasError()) {
       Serial.println(audio.errorMessage());
     } else {
       Serial.print("Cannot load WAV file ");
       Serial.println(audio_files[current_audio_index]);
     }
-    return false;
+
+    // Move to the next track and try again
+    current_audio_index = (current_audio_index + 1) % audio_file_count;
+    attempts++;
   }
-  return true;
+  return false;
 }
 
 void audio_setup() {


### PR DESCRIPTION
## Summary
- skip to the next track when an audio file fails to load

## Testing
- `g++ -std=c++17 -fsyntax-only *.cpp` *(fails: `lvgl.h` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684876a10f348329a626a182193c3348