### PR TITLE
Add audio playback to left panel buttons

### DIFF
--- a/audio_helper.cpp
+++ b/audio_helper.cpp
@@ -4,37 +4,24 @@
 #include <GigaAudio.h>
 
 static GigaAudio audio("USB DISK");
-static const char *audio_files[] = {"intro.wav", "explode.wav", "shoe.wav", "joseph.wav"};
-static const int audio_file_count =
-    sizeof(audio_files) / sizeof(audio_files[0]);
-static int current_audio_index = 0;
 
-static bool load_current_audio() {
-  if (!audio.load(const_cast<char *>(audio_files[current_audio_index]))) {
+void audio_setup() {}
+
+void audio_play_file(const char *filename) {
+  if (!audio.load(const_cast<char *>(filename))) {
     if (audio.hasError()) {
       Serial.println(audio.errorMessage());
     } else {
       Serial.print("Cannot load WAV file ");
-      Serial.println(audio_files[current_audio_index]);
+      Serial.println(filename);
     }
-    return false;
+    return;
   }
-  return true;
+  audio.play();
 }
 
-void audio_setup() {
-  current_audio_index = 0;
-  if (load_current_audio()) {
-    audio.play();
-  }
-}
+void audio_stop() { audio.stop(); }
 
 void audio_loop() {
-  if (audio.isFinished()) {
-    current_audio_index = (current_audio_index + 1) % audio_file_count;
-    if (load_current_audio()) {
-      audio.play();
-      Serial.println("Restarting . . .");
-    }
-  }
+  // Playback stops automatically when the file ends
 }

--- a/audio_helper.h
+++ b/audio_helper.h
@@ -3,5 +3,7 @@
 
 void audio_setup();
 void audio_loop();
+void audio_play_file(const char *filename);
+void audio_stop();
 
 #endif

--- a/config.cpp
+++ b/config.cpp
@@ -4,6 +4,7 @@
 #include "config.h"
 #include "popup.h"
 #include "voice_tile.h"
+#include "audio_helper.h"
 
 // This file implements the callbacks and validation logic declared in
 // config.h. Functions are grouped by purpose for clarity.
@@ -57,6 +58,14 @@ void null_btn(lv_event_t *e) {
     Serial.println(self->getLabel());
   }
 }
+
+void intro_cb(lv_event_t *) { audio_play_file("intro.wav"); }
+
+void explode_cb(lv_event_t *) { audio_play_file("explode.wav"); }
+
+void shoe_cb(lv_event_t *) { audio_play_file("shoe.wav"); }
+
+void joseph_cb(lv_event_t *) { audio_play_file("joseph.wav"); }
 
 void motor_override_cb(lv_event_t *e) {
   Serial.println("MOTOR override callback!");

--- a/config.h
+++ b/config.h
@@ -18,12 +18,16 @@
 #define PANEL_GRID_HEIGHT (PANEL_BUTTON_SIZE * (BUTTON_COUNT / 2) + SPACING * 6)
 
 void null_btn(lv_event_t *e);
+void intro_cb(lv_event_t *e);
+void explode_cb(lv_event_t *e);
+void shoe_cb(lv_event_t *e);
+void joseph_cb(lv_event_t *e);
 
 const ButtonData button_panel1[BUTTON_COUNT] = {
     {"TURBO BOOST", null_btn, false, true}, {"MAP SYSTEM", null_btn, true},
     {"PRINTER", null_btn, true},           {"VOLTAGE OUTPUT", null_btn, true},
-    {"VITAL SCAN", null_btn, false},       {"EVADE", null_btn, false},
-    {"RANGE BRITE", null_btn, false},      {"RADAR IMAGE", null_btn, false},
+    {"INTRO", intro_cb, false},            {"EXPLODE", explode_cb, false},
+    {"SHOE", shoe_cb, false},              {"JOSEPH", joseph_cb, false},
 };
 
 const ButtonData button_panel2[BUTTON_COUNT] = {


### PR DESCRIPTION
## Summary
- add generic audio playback helper
- wire up bottom four left-panel buttons to play INTRO/EXPLODE/SHOE/JOSEPH clips
- update button labels on left panel

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684afce50a38832983cb37a4bf7e7637