### PR TITLE
Add debug prints for audio playback

### DIFF
--- a/audio_helper.cpp
+++ b/audio_helper.cpp
@@ -5,8 +5,14 @@
 
 static GigaAudio audio("USB DISK");
 void audio_play(const char *file) {
-  if (!file)
+  if (!file) {
+    Serial.println("audio_play called with null file");
     return;
+  }
+
+  Serial.print("Attempting to play: ");
+  Serial.println(file);
+
   if (!audio.load(const_cast<char *>(file))) {
     if (audio.hasError()) {
       Serial.println(audio.errorMessage());
@@ -16,5 +22,10 @@ void audio_play(const char *file) {
     }
     return;
   }
+
+  Serial.print("Loaded ");
+  Serial.print(file);
+  Serial.println(" successfully, starting playback");
+
   audio.play();
 }


### PR DESCRIPTION
## Summary
- log file names before attempting playback
- print a message once audio loads successfully

## Testing
- `arduino-cli compile` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b278abfec8329a15f24dc92c7eaa0