### PR TITLE
Add audio clips to buttons

### DIFF
--- a/UI.cpp
+++ b/UI.cpp
@@ -40,7 +40,6 @@ void UI::init() {
   for (int i = 0; i < 3; ++i) {
     Button *btn = voiceTile->getButton(i);
     if (btn) {
-      btn->setCallback(voice_mode_cb);
       btn->setValidate(validate_voice_mode);
     }
   }

--- a/config.cpp
+++ b/config.cpp
@@ -79,6 +79,52 @@ void shoe_btn_cb(lv_event_t *e) {
   audio_play("shoe.wav");
 }
 
+void theme_btn_cb(lv_event_t *e) {
+  Serial.println("THEME clip requested");
+  audio_play("theme.wav");
+}
+
+void auto_cruise_btn_cb(lv_event_t *e) {
+  voice_mode_cb(e);
+  audio_play("auto_cruise.wav");
+}
+
+void normal_cruise_btn_cb(lv_event_t *e) {
+  voice_mode_cb(e);
+  audio_play("normal_cruise.wav");
+}
+
+void pursuit_btn_cb(lv_event_t *e) {
+  voice_mode_cb(e);
+  audio_play("pursuit.wav");
+}
+
+static void play_toggle_clip(Button *btn, const char *on_clip, const char *off_clip) {
+  if (!btn)
+    return;
+  audio_play(btn->isToggled() ? on_clip : off_clip);
+}
+
+void gps_btn_cb(lv_event_t *e) {
+  auto self = static_cast<Button *>(lv_event_get_user_data(e));
+  play_toggle_clip(self, "gps_on.wav", "gps_off.wav");
+}
+
+void radio_btn_cb(lv_event_t *e) {
+  auto self = static_cast<Button *>(lv_event_get_user_data(e));
+  play_toggle_clip(self, "radio_on.wav", "radio_off.wav");
+}
+
+void usb_btn_cb(lv_event_t *e) {
+  auto self = static_cast<Button *>(lv_event_get_user_data(e));
+  play_toggle_clip(self, "usb_on.wav", "usb_off.wav");
+}
+
+void lighting_btn_cb(lv_event_t *e) {
+  auto self = static_cast<Button *>(lv_event_get_user_data(e));
+  play_toggle_clip(self, "lighting_on.wav", "lighting_off.wav");
+}
+
 void motor_override_cb(lv_event_t *e) {
   Serial.println("MOTOR override callback!");
 }
@@ -135,6 +181,7 @@ bool validate_24v(lv_event_t *e) {
       lv_obj_t *tile = lv_obj_get_parent(grid);
       show_error_popup(tile, "Cannot activate 24V MODE while MOTOR is ON");
     }
+    audio_play("error.wav");
     return false;
   }
   if (self->isToggled() && inverter_btn && inverter_btn->isToggled()) {
@@ -144,6 +191,7 @@ bool validate_24v(lv_event_t *e) {
       lv_obj_t *tile = lv_obj_get_parent(grid);
       show_error_popup(tile, "Cannot deactivate 24V MODE while INVERTER is ON");
     }
+    audio_play("error.wav");
     return false;
   }
   return true;
@@ -158,6 +206,7 @@ bool validate_motor(lv_event_t *e) {
       lv_obj_t *tile = lv_obj_get_parent(grid);
       show_error_popup(tile, "Cannot activate MOTOR while 24V MODE is ON");
     }
+    audio_play("error.wav");
     return false;
   }
   return true;
@@ -172,6 +221,7 @@ bool validate_inverter(lv_event_t *e) {
       lv_obj_t *tile = lv_obj_get_parent(grid);
       show_error_popup(tile, "Cannot activate INVERTER while 24V MODE is OFF");
     }
+    audio_play("error.wav");
     return false;
   }
   return true;
@@ -179,5 +229,9 @@ bool validate_inverter(lv_event_t *e) {
 
 bool validate_voice_mode(lv_event_t *e) {
   auto self = static_cast<Button *>(lv_event_get_user_data(e));
-  return !(self && self->isToggled());
+  if (self && self->isToggled()) {
+    audio_play("error.wav");
+    return false;
+  }
+  return true;
 }

--- a/config.h
+++ b/config.h
@@ -23,10 +23,18 @@ void intro_btn_cb(lv_event_t *e);
 void explode_btn_cb(lv_event_t *e);
 void joseph_btn_cb(lv_event_t *e);
 void shoe_btn_cb(lv_event_t *e);
+void theme_btn_cb(lv_event_t *e);
+void auto_cruise_btn_cb(lv_event_t *e);
+void normal_cruise_btn_cb(lv_event_t *e);
+void pursuit_btn_cb(lv_event_t *e);
+void gps_btn_cb(lv_event_t *e);
+void radio_btn_cb(lv_event_t *e);
+void usb_btn_cb(lv_event_t *e);
+void lighting_btn_cb(lv_event_t *e);
 
 const ButtonData button_panel1[BUTTON_COUNT] = {
     {"TURBO BOOST", null_btn, false, true}, {"MAP SYSTEM", null_btn, true},
-    {"PRINTER", null_btn, true},            {"VOLTAGE OUTPUT", null_btn, true},
+    {"PRINTER", null_btn, true},            {"THEME", theme_btn_cb, false},
     {"INTRO", intro_btn_cb, false},         {"EXPLODE", explode_btn_cb, false},
     {"JOSEPH", joseph_btn_cb, false},       {"SHOE", shoe_btn_cb, false},
 };
@@ -34,15 +42,15 @@ const ButtonData button_panel1[BUTTON_COUNT] = {
 const ButtonData button_panel2[BUTTON_COUNT] = {
     {"MOTOR", null_btn, true, true, true},  {"EVADE", null_btn, true, true},
     {"24V MODE", null_btn, true, true},     {"INVERTER", null_btn, true, true},
-    {"GPS", null_btn, true, false, true},   {"RADIO", null_btn, true, false, true},
-    {"USB", null_btn, true, false, true},   {"LIGHTING", null_btn, true},
+    {"GPS", gps_btn_cb, true, false, true},   {"RADIO", radio_btn_cb, true, false, true},
+    {"USB", usb_btn_cb, true, false, true},   {"LIGHTING", lighting_btn_cb, true},
 };
 
 // ==== Voice tile configuration ====
 const ButtonData voice_buttons[3] = {
-    {"AUTO CRUISE", null_btn, true, true},
-    {"NORMAL CRUISE", null_btn, true, true, true},
-    {"PURSUIT", null_btn, true, true},
+    {"AUTO CRUISE", auto_cruise_btn_cb, true, true},
+    {"NORMAL CRUISE", normal_cruise_btn_cb, true, true, true},
+    {"PURSUIT", pursuit_btn_cb, true, true},
 };
 
 // ==== Visualiser configuration ====


### PR DESCRIPTION
## Summary
- rename the VOLTAGE OUTPUT button to THEME and make it momentary
- hook GPS, RADIO, USB and LIGHTING buttons to play on/off clips
- give voice mode buttons dedicated callbacks to play their clips
- play `error.wav` whenever validation fails

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684b637c2cb48329842568bddb4c0a14