### PR TITLE
Add fade-out fallback for voice visualiser

### DIFF
--- a/audio_helper.cpp
+++ b/audio_helper.cpp
@@ -63,5 +63,7 @@ void audio_stop() {
   if (voiceTile) {
     if (voiceTile->getIndicator(0))
       voiceTile->getIndicator(0)->toggle(false);
+    if (voiceTile->getVisualiser())
+      voiceTile->getVisualiser()->startFade();
   }
 }

--- a/audio_helper.cpp
+++ b/audio_helper.cpp
@@ -63,7 +63,5 @@ void audio_stop() {
   if (voiceTile) {
     if (voiceTile->getIndicator(0))
       voiceTile->getIndicator(0)->toggle(false);
-    if (voiceTile->getVisualiser())
-      voiceTile->getVisualiser()->setLevel(0.f);
   }
 }

--- a/voice_synth.cpp
+++ b/voice_synth.cpp
@@ -17,6 +17,8 @@ void voice_anim_cb(lv_timer_t *t) {
     if (was_playing && voiceTile) {
       if (voiceTile->getIndicator(0))
         voiceTile->getIndicator(0)->toggle(false);
+      if (voiceTile->getVisualiser())
+        voiceTile->getVisualiser()->startFade();
     }
     was_playing = false;
     target = 0.f;

--- a/voice_synth.cpp
+++ b/voice_synth.cpp
@@ -17,8 +17,6 @@ void voice_anim_cb(lv_timer_t *t) {
     if (was_playing && voiceTile) {
       if (voiceTile->getIndicator(0))
         voiceTile->getIndicator(0)->toggle(false);
-      if (voiceTile->getVisualiser())
-        voiceTile->getVisualiser()->setLevel(0.f);
     }
     was_playing = false;
     target = 0.f;

--- a/voice_visualiser.cpp
+++ b/voice_visualiser.cpp
@@ -96,6 +96,13 @@ void VoiceVisualiser::setLevel(float lvl) {
   last_update = lv_tick_get();
 }
 
+void VoiceVisualiser::startFade() {
+  if (level > 0.f) {
+    fading = true;
+    last_update = lv_tick_get();
+  }
+}
+
 void VoiceVisualiser::timer_cb(lv_timer_t *t) {
   auto self = static_cast<VoiceVisualiser *>(lv_timer_get_user_data(t));
   if (!self)

--- a/voice_visualiser.cpp
+++ b/voice_visualiser.cpp
@@ -24,6 +24,7 @@ VoiceVisualiser::VoiceVisualiser(lv_obj_t *parent) {
   make_column(2, 19);
 
   timer = lv_timer_create(timer_cb, 50, this); // 20 FPS update
+  last_update = lv_tick_get();
 }
 
 void VoiceVisualiser::make_column(int id, int count) {
@@ -91,11 +92,28 @@ void VoiceVisualiser::setLevel(float lvl) {
   if (lvl > 1.f)
     lvl = 1.f;
   level = lvl;
+  fading = false;
+  last_update = lv_tick_get();
 }
 
 void VoiceVisualiser::timer_cb(lv_timer_t *t) {
   auto self = static_cast<VoiceVisualiser *>(lv_timer_get_user_data(t));
   if (!self)
     return;
+  uint32_t now = lv_tick_get();
+  if (!self->fading) {
+    if (now - self->last_update > 150 && self->level > 0.2f) {
+      self->fading = true;
+    }
+  } else {
+    if (self->level > 0.01f) {
+      self->level -= 0.08f; // fade speed ~600ms total
+      if (self->level < 0.f)
+        self->level = 0.f;
+    } else {
+      self->level = 0.f;
+      self->fading = false;
+    }
+  }
   self->set_cols_active(self->level);
 }

--- a/voice_visualiser.h
+++ b/voice_visualiser.h
@@ -20,6 +20,7 @@ public:
   VoiceVisualiser(lv_obj_t *parent);
   void set_cols_active(float ratio_norm);
   void setLevel(float lvl);
+  void startFade();
   lv_obj_t *getObject() const { return viz; }
 };
 

--- a/voice_visualiser.h
+++ b/voice_visualiser.h
@@ -10,6 +10,8 @@ class VoiceVisualiser {
 
   lv_timer_t *timer = nullptr;
   float level = 0.f; // normalised 0..1 value
+  bool fading = false;
+  uint32_t last_update = 0; // lv_tick timestamp of last level update
 
   void make_column(int id, int count);
   static void timer_cb(lv_timer_t *t);


### PR DESCRIPTION
## Summary
- fade out visualiser if level updates stop mid cycle

## Testing
- `make` *(fails: No targets specified and no makefile found)*
- `arduino-cli --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b902c60988329b042ba332576d775