### PR TITLE
Pass audio instance through UI

### DIFF
--- a/UI.cpp
+++ b/UI.cpp
@@ -7,6 +7,7 @@
 #include "voice_tile.h"
 #include "gauge_tile.h"
 #include "gauge_anim.h"
+#include <GigaAudio.h>
 
 UI ui;
 
@@ -19,7 +20,7 @@ Button *blackout_btn = nullptr;
 Button *btn48v = nullptr;
 Button *inverter_btn = nullptr;
 
-void UI::init() {
+void UI::init(GigaAudio &audio) {
   Serial.print("Initializing UI...");
 
   canvas = lv_scr_act();
@@ -72,7 +73,7 @@ void UI::init() {
 
   lv_obj_set_tile_id(tiles, 2, 0, LV_ANIM_OFF); // start on voice tile
 
-  voice_anim_timer = lv_timer_create(voice_anim_cb, 50, nullptr);
+  voice_anim_timer = lv_timer_create(voice_anim_cb, 50, &audio);
   // Slow down gauge animations so they are less frenetic
   gauge_anim_timer = lv_timer_create(gauge_anim_cb, 150, nullptr);
 

--- a/UI.h
+++ b/UI.h
@@ -2,6 +2,7 @@
 #define UI_H
 
 #include "lvgl_wrapper.h"
+#include <GigaAudio.h>
 
 class ButtonPanel;
 class VoiceTile;
@@ -19,7 +20,7 @@ class UI {
   lv_timer_t *gauge_anim_timer = nullptr;
 
 public:
-  void init();
+  void init(GigaAudio &audio);
   VoiceTile *getVoiceTile() const { return voiceTile; }
   ButtonPanel *getLeftPanel() const { return leftPanel; }
   ButtonPanel *getRightPanel() const { return rightPanel; }

--- a/audio_helper.h
+++ b/audio_helper.h
@@ -1,6 +1,11 @@
 #ifndef AUDIO_HELPER_H
 #define AUDIO_HELPER_H
 
+#include <GigaAudio.h>
+
+// Provide the audio instance used by the helper functions
+void audio_init(GigaAudio &audio);
+
 // Play the specified WAV file once
 void audio_play(const char *file);
 // Maintains playback state if audio_setup() or audio_play() was called

--- a/kitt.ino
+++ b/kitt.ino
@@ -10,11 +10,13 @@
 #include "popup.h"
 #include "voice_synth.h"
 #include "UI.h"
+#include <GigaAudio.h>
 
 GigaDisplay_GFX tft; // Init tft
 Arduino_GigaDisplayTouch TouchDetector;
 GigaDisplayBacklight backlight;
 bool blackout = false;
+GigaAudio audio("USB DISK");
 
 void setup() {
   Serial.begin(115200); // Initialize Serial
@@ -22,7 +24,8 @@ void setup() {
   tft.begin();          // Initialize Giga Display
   TouchDetector.begin();
   backlight.begin();
-  ui.init();
+  audio_init(audio);
+  ui.init(audio);
 
   Serial.println();
 }

--- a/voice_synth.cpp
+++ b/voice_synth.cpp
@@ -3,6 +3,7 @@
 #include "config.h"
 #include "voice_tile.h"
 #include "audio_helper.h"
+#include <GigaAudio.h>
 #include <stdlib.h>
 
 void voice_anim_cb(lv_timer_t *t) {
@@ -10,8 +11,9 @@ void voice_anim_cb(lv_timer_t *t) {
   static float target = 0.f;
   static int hold = 0;
   static bool was_playing = false;
-  (void)t;
-  bool playing = audio_is_playing();
+  GigaAudio *audio =
+      t ? static_cast<GigaAudio *>(lv_timer_get_user_data(t)) : nullptr;
+  bool playing = audio ? audio->isPlaying() : audio_is_playing();
 
   if (!playing) {
     if (was_playing && voiceTile) {

--- a/voice_synth.h
+++ b/voice_synth.h
@@ -2,6 +2,7 @@
 #define VOICE_SYNTH_H
 
 #include "lvgl_wrapper.h"
+#include <GigaAudio.h>
 
 void voice_anim_cb(lv_timer_t *t);
 


### PR DESCRIPTION
## Summary
- allow audio helper to use external `GigaAudio` instance
- update `UI::init` to receive a `GigaAudio&` and pass it to timer callbacks
- pull audio instance from timer in `voice_anim_cb`
- create global audio object in `kitt.ino` and wire it up

## Testing
- `g++ -c voice_synth.cpp -I.` *(fails: `lvgl.h` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c8ee631748329bdcce111722da44f