### PR TITLE
Add error sound to validation failures

### DIFF
--- a/config.cpp
+++ b/config.cpp
@@ -218,6 +218,7 @@ bool validate_48v(lv_event_t *e) {
       lv_obj_t *tile = lv_obj_get_parent(grid);
       show_error_popup(tile, "Cannot deactivate 48V MODE while MOTOR is ON");
     }
+    audio_play("error.wav");
     return false;
   }
   if (!self->isToggled() && inverter_btn && inverter_btn->isToggled()) {
@@ -227,6 +228,7 @@ bool validate_48v(lv_event_t *e) {
       lv_obj_t *tile = lv_obj_get_parent(grid);
       show_error_popup(tile, "Cannot activate 48V MODE while INVERTER is ON");
     }
+    audio_play("error.wav");
     return false;
   }
   return true;
@@ -241,6 +243,7 @@ bool validate_motor(lv_event_t *e) {
       lv_obj_t *tile = lv_obj_get_parent(grid);
       show_error_popup(tile, "Cannot activate MOTOR while 48V MODE is OFF");
     }
+    audio_play("error.wav");
     return false;
   }
   return true;
@@ -255,6 +258,7 @@ bool validate_inverter(lv_event_t *e) {
       lv_obj_t *tile = lv_obj_get_parent(grid);
       show_error_popup(tile, "Cannot activate INVERTER while 48V MODE is ON");
     }
+    audio_play("error.wav");
     return false;
   }
   return true;
@@ -262,5 +266,9 @@ bool validate_inverter(lv_event_t *e) {
 
 bool validate_voice_mode(lv_event_t *e) {
   auto self = static_cast<Button *>(lv_event_get_user_data(e));
-  return !(self && self->isToggled());
+  if (self && self->isToggled()) {
+    audio_play("error.wav");
+    return false;
+  }
+  return true;
 }

--- a/kitt.ino
+++ b/kitt.ino
@@ -12,7 +12,7 @@
 #include <UI.h>
 
 GigaDisplay_GFX tft; // Init tft
-Arduino_GigaDisplayTouch TouchDetector;
+Arduino_GigaDisplayTouch TouchDetector;   
 GigaDisplayBacklight backlight;
 bool blackout = false;
 


### PR DESCRIPTION
## Summary
- play `error.wav` whenever button validation fails

## Testing
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_684c9a5ac7588329b912ce88cfefa3f8